### PR TITLE
Feature: show number of duplicate mails to stats command output

### DIFF
--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -185,6 +185,8 @@ msg!(
 );
 msg!(msg_top_senders, "Top senders", "Principales remitentes");
 msg!(msg_with_attachments, "With attachments", "Con adjuntos");
+msg!(msg_duplicates, "Duplicates", "Duplicados");
+msg!(msg_unique_ids, "Unique IDs", "IDs únicos");
 msg!(
     msg_no_messages,
     "No messages found",

--- a/src/index/reader.rs
+++ b/src/index/reader.rs
@@ -41,6 +41,22 @@ pub fn count_with_attachments(entries: &[MailEntry]) -> usize {
     entries.iter().filter(|e| e.has_attachments).count()
 }
 
+/// Count duplicate messages based on `Message-ID`.
+pub fn count_duplicates(entries: &[MailEntry]) -> (usize, usize) {
+    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut duplicates = 0usize;
+    for e in entries {
+        let id = e.message_id.as_str();
+        if !id.is_empty() {
+            if !seen.insert(id) {
+                duplicates += 1;
+            }
+        }
+    }
+    let unique = seen.len();
+    (duplicates, unique)
+}
+
 /// Return the top N senders by message count.
 pub fn top_senders(entries: &[MailEntry], n: usize) -> Vec<(String, usize)> {
     let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
@@ -56,4 +72,49 @@ pub fn top_senders(entries: &[MailEntry], n: usize) -> Vec<(String, usize)> {
     sorted.sort_by_key(|(_, count)| std::cmp::Reverse(*count));
     sorted.truncate(n);
     sorted
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::address::EmailAddress;
+    use chrono::Utc;
+
+    fn make_entry(idx: u64, message_id: &str) -> MailEntry {
+        MailEntry {
+            offset: idx * 1000,
+            length: 500,
+            date: Utc::now(),
+            from: EmailAddress {
+                display_name: String::new(),
+                address: format!("user{}@example.com", idx),
+            },
+            to: Vec::new(),
+            cc: Vec::new(),
+            subject: String::new(),
+            message_id: message_id.to_string(),
+            in_reply_to: None,
+            references: Vec::new(),
+            has_attachments: false,
+            content_type: "text/plain".to_string(),
+            text_size: 100,
+            labels: Vec::new(),
+            sequence: idx,
+        }
+    }
+
+    #[test]
+    fn test_count_duplicates() {
+        let entries = vec![
+            make_entry(0, "<a@example.com>"),
+            make_entry(1, "<b@example.com>"),
+            make_entry(2, "<a@example.com>"), // duplicate of entry 0
+            make_entry(3, ""),                // no message_id, not a duplicate
+            make_entry(4, "<c@example.com>"),
+            make_entry(5, "<b@example.com>"), // duplicate of entry 1
+        ];
+        let (duplicates, unique_ids) = count_duplicates(&entries);
+        assert_eq!(duplicates, 2);
+        assert_eq!(unique_ids, 3);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -790,6 +790,14 @@ fn print_stats_table(
         }
     );
 
+    let (duplicates, unique_ids) = index_reader::count_duplicates(entries);
+    println!(
+        "  {:<20} {} ({})" ,
+        i18n::msg_duplicates(),
+        duplicates,
+        format!("{} {}", unique_ids, i18n::msg_unique_ids())
+    );
+
     let top = index_reader::top_senders(entries, 10);
     if !top.is_empty() {
         println!();
@@ -827,6 +835,8 @@ fn print_stats_json(
         })
         .collect();
 
+    let (duplicates, unique_ids) = index_reader::count_duplicates(entries);
+
     let stats = serde_json::json!({
         "file": path.to_string_lossy(),
         "file_size": file_size,
@@ -835,6 +845,8 @@ fn print_stats_json(
         "index_size": idx_size,
         "indexing_time_ms": elapsed.as_millis(),
         "with_attachments": index_reader::count_with_attachments(entries),
+        "duplicates": duplicates,
+        "unique_ids": unique_ids,
         "top_senders": top_json,
     });
 


### PR DESCRIPTION
Hi,

This change adds a duplicate count for the `stats` command:

```
~ $ mboxshell stats <file>
(...)
Messages             227
Date range           2018-10-12 — 2020-12-04
Index size           89.92 KiB
Indexing time        145.90µs
With attachments     0 (0.0%)
Duplicates           185 (42 Unique IDs)
                     ^^^^^^^^^^^^^^^^^^^
(...)
```
---

@dcarrero let me know if this makes sense, thanks!