### PR TITLE
v0.6.2: X-Mbox-Source records the real mailbox name, not "mbox"

### DIFF
--- a/CHANGELOG-ES.md
+++ b/CHANGELOG-ES.md
@@ -4,6 +4,12 @@ Todos los cambios relevantes de mboxshell se documentan en este fichero.
 
 El formato sigue [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/) y el proyecto se ajusta a [Semantic Versioning](https://semver.org/lang/es/).
 
+## v0.6.2
+
+Corrige la cabecera de buzón de origen en las exportaciones de Apple Mail. 7 tests nuevos.
+
+- Corregido: **`merge --source-header` ahora escribe el nombre de buzón que conoce el usuario, no `mbox`.** Apple Mail exporta un buzón como una *carpeta* `Inbox.mbox` que contiene un fichero llamado literalmente `mbox`, que es la ruta que se lee de verdad — así que `X-Mbox-Source` quedaba grabada como `mbox` en todos los mensajes de todos esos buzones, dejando el archivo combinado sin trazabilidad, que es justo para lo que existe la cabecera. La etiqueta se toma ahora del paquete `.mbox` contenedor (`Inbox.mbox`), mientras que un fichero llamado `mbox` que *no* esté dentro de un paquete conserva su propio nombre. Los buzones que compartirían etiqueta se desambiguan entre sí anteponiendo directorios padre (`Trabajo/Inbox.mbox` frente a `Personal/Inbox.mbox`), hasta 4 niveles, y el proceso se detiene cuando un nombre ya no puede crecer, de modo que dos entradas idénticas terminan en vez de trepar hasta la raíz del sistema de ficheros. El mismo nombre se pasa al callback de progreso. Nuevo módulo `mailbox_naming` (`presentation_path` / `display_name` / `unique_display_names`); la etiqueta se sigue saneando antes de llegar a la cabecera.
+
 ## v0.6.1
 
 La fusión (merge) gana una cabecera opcional de buzón de origen. 6 tests nuevos.

--- a/CHANGELOG-ES.md
+++ b/CHANGELOG-ES.md
@@ -6,9 +6,12 @@ El formato sigue [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/) y e
 
 ## v0.6.2
 
-Corrige la cabecera de buzón de origen en las exportaciones de Apple Mail. 7 tests nuevos.
+Corrige la cabecera de buzón de origen en las exportaciones de Apple Mail, y documenta el flag que en v0.6.1 salió sin documentar. 7 tests nuevos (202 en total).
 
 - Corregido: **`merge --source-header` ahora escribe el nombre de buzón que conoce el usuario, no `mbox`.** Apple Mail exporta un buzón como una *carpeta* `Inbox.mbox` que contiene un fichero llamado literalmente `mbox`, que es la ruta que se lee de verdad — así que `X-Mbox-Source` quedaba grabada como `mbox` en todos los mensajes de todos esos buzones, dejando el archivo combinado sin trazabilidad, que es justo para lo que existe la cabecera. La etiqueta se toma ahora del paquete `.mbox` contenedor (`Inbox.mbox`), mientras que un fichero llamado `mbox` que *no* esté dentro de un paquete conserva su propio nombre. Los buzones que compartirían etiqueta se desambiguan entre sí anteponiendo directorios padre (`Trabajo/Inbox.mbox` frente a `Personal/Inbox.mbox`), hasta 4 niveles, y el proceso se detiene cuando un nombre ya no puede crecer, de modo que dos entradas idénticas terminan en vez de trepar hasta la raíz del sistema de ficheros. El mismo nombre se pasa al callback de progreso. Nuevo módulo `mailbox_naming` (`presentation_path` / `display_name` / `unique_display_names`); la etiqueta se sigue saneando antes de llegar a la cabecera.
+- Corregido: **la documentación describía un flag `merge --dedup` que no existe.** La deduplicación está activada por defecto y el flag real es `--no-dedup`; los dos READMEs y los dos manuales decían lo contrario, así que quien copiaba el comando documentado se llevaba un error. `--source-header` salió en v0.6.1 sin documentación ninguna — ahora está cubierto en READMEs y manuales, con la regla de nombres de Apple Mail explicada.
+- Corregido: la línea de resumen del merge `Tagged with source` estaba escrita en inglés a pelo, mientras el resto pasaba por el catálogo de idiomas — ahora está traducida (`Etiquetados con origen`).
+- Mantenimiento: recuperado un `cargo fmt --check` y un `cargo clippy -D warnings` limpios con la toolchain estable actual, cuyo estilo y lints (`clippy::question_mark`) habían empezado a rechazar código que ya estaba en `main`.
 
 ## v0.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to mboxshell are documented in this file.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.6.2
+
+Fixes the source-mailbox header on Apple Mail exports. 7 new tests.
+
+- Fix: **`merge --source-header` now writes the mailbox name the user knows, not `mbox`.** Apple Mail exports a mailbox as a *directory* `Inbox.mbox` containing a file called literally `mbox`, which is the path actually read — so `X-Mbox-Source` was stamped `mbox` on every message of every such mailbox, making a merged archive untraceable, which is the one thing the header exists for. The label is now taken from the containing `.mbox` package (`Inbox.mbox`), while a file named `mbox` that is *not* inside a package keeps its own name. Mailboxes that would end up sharing a label are disambiguated against each other by prepending parent directories (`Work/Inbox.mbox` vs `Personal/Inbox.mbox`), up to 4 levels, stopping when a name can no longer grow so identical inputs terminate instead of climbing to the filesystem root. The same name is passed to the progress callback. New `mailbox_naming` module (`presentation_path` / `display_name` / `unique_display_names`); the label is still sanitized before it reaches the header.
+
 ## v0.6.1
 
 Merge gains an optional source-mailbox header. 6 new tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## v0.6.2
 
-Fixes the source-mailbox header on Apple Mail exports. 7 new tests.
+Fixes the source-mailbox header on Apple Mail exports, and documents the flag that shipped undocumented in v0.6.1. 7 new tests (202 total).
 
 - Fix: **`merge --source-header` now writes the mailbox name the user knows, not `mbox`.** Apple Mail exports a mailbox as a *directory* `Inbox.mbox` containing a file called literally `mbox`, which is the path actually read — so `X-Mbox-Source` was stamped `mbox` on every message of every such mailbox, making a merged archive untraceable, which is the one thing the header exists for. The label is now taken from the containing `.mbox` package (`Inbox.mbox`), while a file named `mbox` that is *not* inside a package keeps its own name. Mailboxes that would end up sharing a label are disambiguated against each other by prepending parent directories (`Work/Inbox.mbox` vs `Personal/Inbox.mbox`), up to 4 levels, stopping when a name can no longer grow so identical inputs terminate instead of climbing to the filesystem root. The same name is passed to the progress callback. New `mailbox_naming` module (`presentation_path` / `display_name` / `unique_display_names`); the label is still sanitized before it reaches the header.
+- Fix: **the docs described a `merge --dedup` flag that does not exist.** Deduplication is on by default and the real flag is `--no-dedup`; both READMEs and both manuals said otherwise, so anyone copying the documented command got an error. `--source-header` shipped in v0.6.1 without any documentation at all — it is now covered in the READMEs and manuals, with the Apple Mail naming rule spelled out.
+- Fix: the merge summary line `Tagged with source` was hardcoded in English while every other line went through the catalogue — it is now translated (`Etiquetados con origen`).
+- Chore: restored a clean `cargo fmt --check` and `cargo clippy -D warnings` under the current stable toolchain, whose style and lints (`clippy::question_mark`) had begun rejecting code already on `main`.
 
 ## v0.6.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "mboxshell"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mboxshell"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 rust-version = "1.85"
 description = "Fast terminal viewer for MBOX files of any size. Open, search and export emails from Gmail Takeout backups (50GB+) without loading them into memory."

--- a/README-ES.md
+++ b/README-ES.md
@@ -132,8 +132,11 @@ mboxshell export correo.mbox --format csv --output resumen.csv
 # Extraer adjuntos
 mboxshell attachments correo.mbox --output ./adjuntos/
 
-# Combinar varios MBOX eliminando duplicados
-mboxshell merge archivo1.mbox archivo2.mbox -o combinado.mbox --dedup
+# Combinar varios MBOX (los duplicados se eliminan por defecto)
+mboxshell merge archivo1.mbox archivo2.mbox -o combinado.mbox
+
+# Combinar etiquetando cada mensaje con el buzón del que viene
+mboxshell merge Inbox.mbox Sent.mbox -o combinado.mbox --source-header
 
 # Generar completions para tu shell
 mboxshell completions bash > /etc/bash_completion.d/mboxshell
@@ -151,7 +154,7 @@ mboxshell completions fish > ~/.config/fish/completions/mboxshell.fish
 | `mboxshell stats <ruta> [--json]` | Mostrar estadisticas de un archivo MBOX |
 | `mboxshell search <ruta> <consulta> [--json]` | Buscar mensajes desde la linea de comandos |
 | `mboxshell export <ruta> -f <formato> -o <salida> [--query <q>]` | Exportar mensajes (formatos: eml, csv, txt, html) |
-| `mboxshell merge <archivos...> -o <salida> [--dedup]` | Combinar varios archivos MBOX en uno |
+| `mboxshell merge <archivos...> -o <salida> [--no-dedup] [--source-header]` | Combinar varios archivos MBOX en uno |
 | `mboxshell attachments <ruta> -o <salida>` | Extraer todos los adjuntos |
 | `mboxshell completions <shell>` | Generar completions de shell (bash, zsh, fish, powershell, elvish) |
 | `mboxshell manpage` | Generar pagina de manual |
@@ -163,6 +166,15 @@ mboxshell completions fish > ~/.config/fish/completions/mboxshell.fish
 | `-f`, `--force` | Forzar reconstruccion del indice aunque exista |
 | `-v`, `--verbose` | Aumentar verbosidad del log (-v info, -vv debug, -vvv trace) |
 | `--lang <en\|es>` | Forzar idioma de la interfaz (auto-detectado por defecto) |
+
+**Flags de merge:**
+
+| Flag | Descripción |
+|------|-------------|
+| `--no-dedup` | Omitir la detección de Message-ID duplicados y concatenar las entradas byte a byte (la deduplicación está activada por defecto) |
+| `--source-header` | Inyectar una cabecera `X-Mbox-Source: <nombre de buzón>` en cada mensaje, para que el archivo combinado siga siendo trazable hasta el buzón del que vino cada correo |
+
+La etiqueta de origen es el nombre de buzón que tú ves: en una exportación de Apple Mail —una carpeta `Inbox.mbox` que contiene un fichero llamado literalmente `mbox`— pone `Inbox.mbox`, no `mbox`. Los buzones que compartirían etiqueta se desambiguan entre sí (`Trabajo/Inbox.mbox` frente a `Personal/Inbox.mbox`).
 
 ## Interfaz de terminal
 

--- a/README-ES.md
+++ b/README-ES.md
@@ -280,6 +280,7 @@ src/
 +-- lib.rs               # Re-exporta modulos
 +-- error.rs             # Tipos de error con thiserror
 +-- config.rs            # Configuracion TOML
++-- mailbox_naming.rs    # Nombres de buzon visibles (paquetes de Apple Mail)
 +-- i18n/                # Internacionalizacion (EN/ES)
 +-- parser/
 |   +-- mbox.rs          # Parser streaming (nunca carga el archivo en memoria)
@@ -305,7 +306,7 @@ src/
 |   +-- csv.rs           # Exportar resumen a CSV (UTF-8 BOM)
 |   +-- text.rs          # Exportar a texto plano
 |   +-- attachment.rs    # Extraccion de adjuntos
-|   +-- mbox.rs          # Merge de MBOX con deduplicacion
+|   +-- mbox.rs          # Merge de MBOX con deduplicacion y cabecera de origen
 +-- tui/
     +-- app.rs           # Estado global (Elm Architecture)
     +-- event.rs         # Manejo de eventos de teclado

--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ src/
 +-- lib.rs               # Module re-exports
 +-- error.rs             # Error types with thiserror
 +-- config.rs            # TOML configuration
++-- mailbox_naming.rs    # Human-facing mailbox names (Apple Mail packages)
 +-- i18n/                # Internationalization (EN/ES)
 +-- parser/
 |   +-- mbox.rs          # Streaming parser (never loads the file into memory)
@@ -305,7 +306,7 @@ src/
 |   +-- csv.rs           # Export summary to CSV (UTF-8 BOM)
 |   +-- text.rs          # Export to plain text
 |   +-- attachment.rs    # Attachment extraction
-|   +-- mbox.rs          # MBOX merge with deduplication
+|   +-- mbox.rs          # MBOX merge with deduplication and source header
 +-- tui/
     +-- app.rs           # Global state (Elm Architecture)
     +-- event.rs         # Keyboard event handling

--- a/README.md
+++ b/README.md
@@ -132,8 +132,11 @@ mboxshell export mail.mbox --format csv --output summary.csv
 # Extract attachments
 mboxshell attachments mail.mbox --output ./attachments/
 
-# Merge multiple MBOX files, removing duplicates
-mboxshell merge file1.mbox file2.mbox -o merged.mbox --dedup
+# Merge multiple MBOX files (duplicates are removed by default)
+mboxshell merge file1.mbox file2.mbox -o merged.mbox
+
+# Merge tagging every message with the mailbox it came from
+mboxshell merge Inbox.mbox Sent.mbox -o merged.mbox --source-header
 
 # Generate shell completions
 mboxshell completions bash > /etc/bash_completion.d/mboxshell
@@ -151,7 +154,7 @@ mboxshell completions fish > ~/.config/fish/completions/mboxshell.fish
 | `mboxshell stats <path> [--json]` | Show statistics about an MBOX file |
 | `mboxshell search <path> <query> [--json]` | Search messages from the command line |
 | `mboxshell export <path> -f <format> -o <output> [--query <q>]` | Export messages (formats: eml, csv, txt, html) |
-| `mboxshell merge <files...> -o <output> [--dedup]` | Merge multiple MBOX files into one |
+| `mboxshell merge <files...> -o <output> [--no-dedup] [--source-header]` | Merge multiple MBOX files into one |
 | `mboxshell attachments <path> -o <output>` | Extract all attachments |
 | `mboxshell completions <shell>` | Generate shell completions (bash, zsh, fish, powershell, elvish) |
 | `mboxshell manpage` | Generate a man page |
@@ -163,6 +166,15 @@ mboxshell completions fish > ~/.config/fish/completions/mboxshell.fish
 | `-f`, `--force` | Force rebuild index even if one exists |
 | `-v`, `--verbose` | Increase log verbosity (-v info, -vv debug, -vvv trace) |
 | `--lang <en\|es>` | Force interface language (auto-detected by default) |
+
+**Merge flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--no-dedup` | Skip duplicate-Message-ID detection and concatenate the inputs byte-for-byte (dedup is on by default) |
+| `--source-header` | Inject an `X-Mbox-Source: <mailbox name>` header into every message, so a merged archive stays traceable to the mailbox each email came from |
+
+The source label is the mailbox name you see: for an Apple Mail export — a directory `Inbox.mbox` containing a file literally called `mbox` — it reads `Inbox.mbox`, not `mbox`. Mailboxes that would end up sharing a label are disambiguated against each other (`Work/Inbox.mbox` vs `Personal/Inbox.mbox`).
 
 ## Terminal UI
 

--- a/docs/MANUAL-ES.md
+++ b/docs/MANUAL-ES.md
@@ -1,7 +1,7 @@
 # mboxShell — Manual de usuario
 
 > Guía completa de todas las funciones de `mboxShell`, el visor rápido de MBOX para terminal.
-> **Válido para mboxShell v0.6.0.**
+> **Válido para mboxShell v0.6.2.**
 > Versión en inglés: [MANUAL.md](MANUAL.md) · Resumen breve: [../README-ES.md](../README-ES.md) · Cambios: [../CHANGELOG-ES.md](../CHANGELOG-ES.md)
 
 `mboxShell` abre, busca y exporta ficheros `.mbox` de cualquier tamaño (más de 50 GB) desde la terminal, sin cargar nunca el fichero entero en memoria y **sin modificar jamás el fichero original** (es estrictamente de solo lectura).
@@ -116,7 +116,7 @@ mboxshell export correo.mbox --format eml --output ./emails/
 mboxshell attachments correo.mbox --output ./adjuntos/
 
 # Fusionar varios buzones en uno, descartando duplicados
-mboxshell merge a.mbox b.mbox -o fusionado.mbox --dedup
+mboxshell merge a.mbox b.mbox -o fusionado.mbox
 ```
 
 ---
@@ -150,7 +150,7 @@ mboxshell [FLAGS GLOBALES] <FICHERO>     # sin comando = abrir <FICHERO> en la T
 | `stats <ruta> [--json]` | Mostrar estadísticas (nº de mensajes, rango de fechas, remitentes top, …) |
 | `search <ruta> <consulta> [--json]` | Buscar y mostrar los mensajes coincidentes |
 | `export <ruta> -o <salida> [opciones]` | Exportar mensajes (ver abajo) |
-| `merge <entradas...> -o <salida> [--dedup]` | Fusionar varios ficheros MBOX en uno |
+| `merge <entradas...> -o <salida> [--no-dedup] [--source-header]` | Fusionar varios ficheros MBOX en uno |
 | `attachments <ruta> -o <salida>` | Extraer todos los adjuntos a una carpeta |
 | `completions <shell>` | Imprimir el script de autocompletado (`bash`, `zsh`, `fish`, `powershell`, `elvish`) |
 | `manpage` | Imprimir una página de manual por stdout |
@@ -406,10 +406,13 @@ En la TUI, pulsa `e` sobre un mensaje para abrir el popup de exportación y eleg
 ### Fusionar buzones
 
 ```bash
-mboxshell merge recibidos.mbox archivo.mbox -o todo.mbox --dedup
+mboxshell merge recibidos.mbox archivo.mbox -o todo.mbox
+mboxshell merge Inbox.mbox Sent.mbox -o todo.mbox --source-header
 ```
 
-`merge` concatena varios ficheros MBOX en uno. `--dedup` (activado por defecto) elimina mensajes duplicados (por Message-ID / contenido), así que fusionar exportaciones de Takeout solapadas es seguro.
+`merge` concatena varios ficheros MBOX en uno. Los mensajes duplicados (por Message-ID) se eliminan por defecto, así que fusionar exportaciones de Takeout solapadas es seguro; pasa `--no-dedup` para concatenar las entradas byte a byte.
+
+`--source-header` inyecta una cabecera `X-Mbox-Source: <nombre de buzón>` en cada mensaje, para que el archivo combinado siga siendo trazable hasta el buzón del que vino cada correo. La etiqueta es el nombre de buzón que tú ves: en una exportación de Apple Mail —una carpeta `Inbox.mbox` que contiene un fichero llamado literalmente `mbox`— pone `Inbox.mbox`, no `mbox`. Los buzones que compartirían etiqueta se desambiguan entre sí (`Trabajo/Inbox.mbox` frente a `Personal/Inbox.mbox`).
 
 ### Extraer adjuntos
 

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -1,7 +1,7 @@
 # mboxShell — User Manual
 
 > Complete guide to every feature of `mboxShell`, the fast terminal MBOX viewer.
-> **Applies to mboxShell v0.6.0.**
+> **Applies to mboxShell v0.6.2.**
 > Spanish version: [MANUAL-ES.md](MANUAL-ES.md) · Short overview: [../README.md](../README.md) · Changes: [../CHANGELOG.md](../CHANGELOG.md)
 
 `mboxShell` opens, searches and exports `.mbox` files of any size (50 GB+) from the terminal, without ever loading the whole file into memory and **without ever modifying the source file** (it is strictly read-only).
@@ -116,7 +116,7 @@ mboxshell export mail.mbox --format eml --output ./emails/
 mboxshell attachments mail.mbox --output ./attachments/
 
 # Merge several mailboxes into one, dropping duplicates
-mboxshell merge a.mbox b.mbox -o merged.mbox --dedup
+mboxshell merge a.mbox b.mbox -o merged.mbox
 ```
 
 ---
@@ -150,7 +150,7 @@ mboxshell [GLOBAL FLAGS] <FILE>        # no command = open <FILE> in the TUI
 | `stats <path> [--json]` | Print statistics (message count, date range, top senders, …) |
 | `search <path> <query> [--json]` | Search and print matching messages |
 | `export <path> -o <out> [options]` | Export messages (see below) |
-| `merge <inputs...> -o <out> [--dedup]` | Merge several MBOX files into one |
+| `merge <inputs...> -o <out> [--no-dedup] [--source-header]` | Merge several MBOX files into one |
 | `attachments <path> -o <out>` | Extract all attachments into a directory |
 | `completions <shell>` | Print shell completion script (`bash`, `zsh`, `fish`, `powershell`, `elvish`) |
 | `manpage` | Print a man page to stdout |
@@ -406,10 +406,13 @@ In the TUI, press `e` on a message to open the export popup and choose a format 
 ### Merging mailboxes
 
 ```bash
-mboxshell merge inbox.mbox archive.mbox -o all.mbox --dedup
+mboxshell merge inbox.mbox archive.mbox -o all.mbox
+mboxshell merge Inbox.mbox Sent.mbox -o all.mbox --source-header
 ```
 
-`merge` concatenates several MBOX files into one. `--dedup` (on by default) removes duplicate messages (by Message-ID / content), so merging overlapping Takeout exports is safe.
+`merge` concatenates several MBOX files into one. Duplicate messages (by Message-ID) are removed by default, so merging overlapping Takeout exports is safe; pass `--no-dedup` to concatenate the inputs byte-for-byte instead.
+
+`--source-header` injects an `X-Mbox-Source: <mailbox name>` header into every message, so the merged archive stays traceable to the mailbox each email came from. The label is the mailbox name you see: for an Apple Mail export — a directory `Inbox.mbox` holding a file literally called `mbox` — it reads `Inbox.mbox`, not `mbox`. Mailboxes that would share a label are disambiguated against each other (`Work/Inbox.mbox` vs `Personal/Inbox.mbox`).
 
 ### Extracting attachments
 

--- a/src/export/mbox.rs
+++ b/src/export/mbox.rs
@@ -5,6 +5,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use crate::index::builder;
+use crate::mailbox_naming;
 
 /// Statistics returned by a merge operation.
 #[derive(Debug)]
@@ -23,12 +24,16 @@ pub struct MergeStats {
 /// (the first occurrence is kept).
 ///
 /// If `add_source_header` is true, every message gets an
-/// `X-Mbox-Source: <origin file name>` header injected as its first header, so
+/// `X-Mbox-Source: <mailbox name>` header injected as its first header, so
 /// the merged archive stays traceable back to which mailbox each email came
 /// from. This forces the per-message path (it needs message boundaries), so it
 /// is slower than the raw byte-exact block copy used by a plain no-dedup merge.
 ///
-/// The progress callback receives `(current_file, total_files, filename)`.
+/// The mailbox name is the one the user sees (`Inbox.mbox`, not Apple Mail's
+/// inner `mbox` file), disambiguated across the inputs when two of them would
+/// otherwise share a name — see [`crate::mailbox_naming`].
+///
+/// The progress callback receives `(current_file, total_files, mailbox_name)`.
 pub fn merge_mbox_files(
     inputs: &[PathBuf],
     output: &Path,
@@ -47,21 +52,23 @@ pub fn merge_mbox_files(
     let mut source_header_added: u64 = 0;
     let total_files = inputs.len();
 
+    // Name every input the way the user sees it, disambiguated as a set: taking
+    // `file_name()` here would label every Apple Mail package "mbox".
+    let mailbox_names = mailbox_naming::unique_display_names(inputs);
+
     for (file_idx, input_path) in inputs.iter().enumerate() {
-        let filename = input_path
-            .file_name()
-            .map(|n| n.to_string_lossy().to_string())
-            .unwrap_or_else(|| input_path.to_string_lossy().to_string());
-        progress(file_idx, total_files, &filename);
+        let filename = mailbox_names[file_idx].as_str();
+        progress(file_idx, total_files, filename);
 
         // Both dedup and source-header injection need per-message boundaries, so
         // they share the parsing path. A plain no-dedup / no-header merge stays
         // on the fast raw block copy below.
         if dedup || add_source_header {
-            // The source label is the origin file name (e.g. "Inbox.mbox"),
-            // sanitized so a crafted name can't inject extra headers.
+            // The source label is the mailbox name (e.g. "Inbox.mbox"),
+            // sanitized so a crafted name can't inject extra headers. A
+            // disambiguated name may carry a `/`, harmless in a header value.
             let source_label = if add_source_header {
-                sanitize_header_value(&filename)
+                sanitize_header_value(filename)
             } else {
                 String::new()
             };
@@ -324,5 +331,69 @@ mod tests {
         let merged = String::from_utf8(std::fs::read(&out).unwrap()).unwrap();
         assert!(merged.contains("X-Mbox-Source: Inbox.mbox"));
         assert!(merged.contains("X-Mbox-Source: Sent.mbox"));
+    }
+
+    #[test]
+    fn test_source_header_names_apple_mail_packages() {
+        // Apple Mail stores each mailbox as a DIRECTORY "Inbox.mbox" holding a
+        // file literally called "mbox" — the path the app actually reads. The
+        // header must carry the package name, not "mbox".
+        let dir = tempfile::tempdir().unwrap();
+        let inbox_pkg = dir.path().join("Inbox.mbox");
+        let sent_pkg = dir.path().join("Sent.mbox");
+        std::fs::create_dir(&inbox_pkg).unwrap();
+        std::fs::create_dir(&sent_pkg).unwrap();
+
+        let inbox = inbox_pkg.join("mbox");
+        let sent = sent_pkg.join("mbox");
+        std::fs::write(
+            &inbox,
+            b"From x@y Thu Jan 01 00:00:00 2024\nSubject: A\n\nbody\n",
+        )
+        .unwrap();
+        std::fs::write(
+            &sent,
+            b"From z@w Fri Jan 02 00:00:00 2024\nSubject: B\n\nhi\n",
+        )
+        .unwrap();
+
+        let out = dir.path().join("out.mbox");
+        let stats = merge_mbox_files(&[inbox, sent], &out, true, true, &|_, _, _| {}).unwrap();
+
+        assert_eq!(stats.source_header_added, 2);
+        let merged = String::from_utf8(std::fs::read(&out).unwrap()).unwrap();
+        assert!(merged.contains("X-Mbox-Source: Inbox.mbox"));
+        assert!(merged.contains("X-Mbox-Source: Sent.mbox"));
+        assert!(
+            !merged.contains("X-Mbox-Source: mbox"),
+            "the inner file name must never be used as the source label"
+        );
+    }
+
+    #[test]
+    fn test_source_header_disambiguates_same_named_packages() {
+        // Two accounts, both with an "Inbox.mbox": the labels must stay
+        // distinguishable, otherwise the header can't say where a mail is from.
+        let dir = tempfile::tempdir().unwrap();
+        let work = dir.path().join("Work").join("Inbox.mbox");
+        let personal = dir.path().join("Personal").join("Inbox.mbox");
+        std::fs::create_dir_all(&work).unwrap();
+        std::fs::create_dir_all(&personal).unwrap();
+
+        let a = work.join("mbox");
+        let b = personal.join("mbox");
+        std::fs::write(
+            &a,
+            b"From x@y Thu Jan 01 00:00:00 2024\nSubject: A\n\nbody\n",
+        )
+        .unwrap();
+        std::fs::write(&b, b"From z@w Fri Jan 02 00:00:00 2024\nSubject: B\n\nhi\n").unwrap();
+
+        let out = dir.path().join("out.mbox");
+        merge_mbox_files(&[a, b], &out, true, true, &|_, _, _| {}).unwrap();
+
+        let merged = String::from_utf8(std::fs::read(&out).unwrap()).unwrap();
+        assert!(merged.contains("X-Mbox-Source: Work/Inbox.mbox"));
+        assert!(merged.contains("X-Mbox-Source: Personal/Inbox.mbox"));
     }
 }

--- a/src/export/mbox.rs
+++ b/src/export/mbox.rs
@@ -159,7 +159,8 @@ fn inject_source_header(raw: &[u8], source: &str) -> Vec<u8> {
     let body = &raw[start..];
     if body.starts_with(b"From ") {
         if let Some(rel_nl) = body.iter().position(|&b| b == b'\n') {
-            let nl = start + rel_nl; // index of the '\n' in `raw`
+            // Index of the newline ending the envelope line, relative to `raw`.
+            let nl = start + rel_nl;
             // Match the envelope line's terminator so we don't mix CRLF and LF.
             let terminator: &[u8] = if nl > 0 && raw[nl - 1] == 0x0D {
                 b"\r\n"
@@ -316,11 +317,7 @@ mod tests {
             b"From x@y Thu Jan 01 00:00:00 2024\nSubject: A\n\nbody\n",
         )
         .unwrap();
-        std::fs::write(
-            &b,
-            b"From z@w Fri Jan 02 00:00:00 2024\nSubject: B\n\nhi\n",
-        )
-        .unwrap();
+        std::fs::write(&b, b"From z@w Fri Jan 02 00:00:00 2024\nSubject: B\n\nhi\n").unwrap();
 
         let out = dir.path().join("out.mbox");
         // dedup off, source header on: proves the two options are independent.

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -610,6 +610,11 @@ msg!(
     "Duplicates removed",
     "Duplicados eliminados"
 );
+msg!(
+    cli_tagged_with_source,
+    "Tagged with source",
+    "Etiquetados con origen"
+);
 msg!(cli_output_size, "Output size", "Tama\u{f1}o de salida");
 msg!(cli_output_file, "Output file", "Fichero de salida");
 msg!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod error;
 pub mod export;
 pub mod i18n;
 pub mod index;
+pub mod mailbox_naming;
 pub mod model;
 pub mod parser;
 pub mod search;

--- a/src/mailbox_naming.rs
+++ b/src/mailbox_naming.rs
@@ -1,0 +1,172 @@
+//! Human-facing mailbox names.
+//!
+//! Apple Mail exports a mailbox as a *directory* named `Inbox.mbox` holding a
+//! single file literally called `mbox`. Taking `file_name()` of the path we
+//! actually read therefore yields `"mbox"` for every such mailbox — useless as
+//! a label, and actively misleading in the `X-Mbox-Source` header written by a
+//! merge. These helpers name a mailbox the way the user sees it.
+
+use std::collections::HashMap;
+use std::path::{Component, Path, PathBuf};
+
+/// Maximum number of trailing path components used to tell two mailboxes apart.
+/// Without a cap, identical paths would climb to the filesystem root forever.
+const MAX_LEVELS: usize = 4;
+
+/// The path that represents the mailbox *to the user*: the containing
+/// `Name.mbox` package when `path` is Apple Mail's inner file, `path` itself
+/// otherwise.
+///
+/// A file called `mbox` that is *not* inside a `.mbox` package keeps its own
+/// name — it is a mailbox in its own right (Thunderbird stores look like this).
+pub fn presentation_path(path: &Path) -> &Path {
+    let is_inner = path
+        .file_name()
+        .is_some_and(|n| n.eq_ignore_ascii_case("mbox"));
+    if !is_inner {
+        return path;
+    }
+    match path.parent() {
+        Some(parent)
+            if parent
+                .extension()
+                .is_some_and(|e| e.eq_ignore_ascii_case("mbox")) =>
+        {
+            parent
+        }
+        _ => path,
+    }
+}
+
+/// Visible name of a single mailbox: `Inbox.mbox` for `…/Account/Inbox.mbox/mbox`.
+pub fn display_name(path: &Path) -> String {
+    name_at_level(presentation_path(path), 1)
+}
+
+/// Visible names for a set of mailboxes, disambiguated *against each other*.
+///
+/// Mailboxes that would share a name get their parent directory prepended
+/// (`Work/Inbox.mbox` vs `Personal/Inbox.mbox`), repeatedly, up to
+/// [`MAX_LEVELS`]. Names that can no longer grow — the filesystem root is
+/// reached, or two entries are genuinely the same path — are left as they are
+/// instead of looping.
+pub fn unique_display_names(paths: &[PathBuf]) -> Vec<String> {
+    let presented: Vec<&Path> = paths.iter().map(|p| presentation_path(p)).collect();
+    let mut levels = vec![1usize; paths.len()];
+    let mut names: Vec<String> = presented.iter().map(|p| name_at_level(p, 1)).collect();
+
+    // Each round lets every still-colliding name grow by one component.
+    for _ in 1..MAX_LEVELS {
+        let mut groups: HashMap<String, Vec<usize>> = HashMap::new();
+        for (i, name) in names.iter().enumerate() {
+            groups.entry(name.clone()).or_default().push(i);
+        }
+        let colliding: Vec<usize> = groups
+            .into_values()
+            .filter(|idx| idx.len() > 1)
+            .flatten()
+            .collect();
+        if colliding.is_empty() {
+            break;
+        }
+
+        let mut grew = false;
+        for i in colliding {
+            let next = levels[i] + 1;
+            let candidate = name_at_level(presented[i], next);
+            if candidate != names[i] {
+                names[i] = candidate;
+                levels[i] = next;
+                grew = true;
+            }
+        }
+        if !grew {
+            break; // identical paths, or nothing left to prepend
+        }
+    }
+
+    names
+}
+
+/// The last `level` path components, joined with `/`.
+///
+/// Only `Normal` components count, so drive prefixes and root separators never
+/// end up in a user-facing name. A path with no normal components at all (a
+/// bare root) falls back to its own string form.
+fn name_at_level(path: &Path, level: usize) -> String {
+    let components: Vec<String> = path
+        .components()
+        .filter_map(|c| match c {
+            Component::Normal(part) => Some(part.to_string_lossy().to_string()),
+            _ => None,
+        })
+        .collect();
+
+    if components.is_empty() {
+        return path.to_string_lossy().to_string();
+    }
+    let start = components.len().saturating_sub(level);
+    components[start..].join("/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display_name_apple_mail_package() {
+        // The real case: the path we read is the inner file, the name the user
+        // knows is the package around it.
+        let path = Path::new("/tmp/Account/Inbox.mbox/mbox");
+        assert_eq!(display_name(path), "Inbox.mbox");
+        assert_eq!(
+            presentation_path(path),
+            Path::new("/tmp/Account/Inbox.mbox"),
+        );
+    }
+
+    #[test]
+    fn test_display_name_plain_files() {
+        assert_eq!(display_name(Path::new("/tmp/archive.mbox")), "archive.mbox");
+        // A file called "mbox" outside a .mbox package is its own mailbox.
+        assert_eq!(display_name(Path::new("/tmp/backup/mbox")), "mbox");
+    }
+
+    #[test]
+    fn test_unique_display_names_disambiguates_by_parent() {
+        let paths = vec![
+            PathBuf::from("/tmp/Work/Inbox.mbox/mbox"),
+            PathBuf::from("/tmp/Personal/Inbox.mbox/mbox"),
+        ];
+        assert_eq!(
+            unique_display_names(&paths),
+            vec!["Work/Inbox.mbox", "Personal/Inbox.mbox"],
+        );
+    }
+
+    #[test]
+    fn test_unique_display_names_identical_paths_terminate() {
+        // Two identical paths can never be told apart: the loop must stop
+        // instead of climbing to the root.
+        let paths = vec![
+            PathBuf::from("/tmp/Work/Inbox.mbox/mbox"),
+            PathBuf::from("/tmp/Work/Inbox.mbox/mbox"),
+        ];
+        let names = unique_display_names(&paths);
+        assert_eq!(names.len(), 2);
+        assert_eq!(names[0], names[1]);
+    }
+
+    #[test]
+    fn test_unique_display_names_leaves_distinct_names_short() {
+        let paths = vec![
+            PathBuf::from("/tmp/Work/Inbox.mbox/mbox"),
+            PathBuf::from("/tmp/Work/Sent.mbox/mbox"),
+            PathBuf::from("/tmp/other/archive.mbox"),
+        ];
+        assert_eq!(
+            unique_display_names(&paths),
+            vec!["Inbox.mbox", "Sent.mbox", "archive.mbox"],
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,8 +80,10 @@ enum Commands {
         /// byte-for-byte (preserves original bytes and line endings).
         #[arg(long)]
         no_dedup: bool,
-        /// Inject an `X-Mbox-Source: <origin file name>` header into every
-        /// message so the merged archive stays traceable to its source mailbox.
+        /// Inject an `X-Mbox-Source: <mailbox name>` header into every message
+        /// so the merged archive stays traceable to its source mailbox. The
+        /// name is the one you see (`Inbox.mbox`, not Apple Mail's inner
+        /// `mbox` file).
         #[arg(long)]
         source_header: bool,
     },
@@ -604,7 +606,11 @@ fn cmd_merge(
         );
     }
     if add_source_header {
-        println!("  {:<25} {}", "Tagged with source:", stats.source_header_added);
+        println!(
+            "  {:<25} {}",
+            i18n::cli_tagged_with_source(),
+            stats.source_header_added
+        );
     }
     println!(
         "  {:<25} {}",

--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -352,12 +352,10 @@ fn parse_flexible_date_end(s: &str) -> Option<NaiveDate> {
 
 /// Parse a size filter like `>1mb` or `<100kb`.
 fn parse_size_filter(value: &str) -> Option<SizeFilter> {
-    let (cmp, rest) = if let Some(r) = value.strip_prefix('>') {
-        (true, r)
-    } else if let Some(r) = value.strip_prefix('<') {
-        (false, r)
-    } else {
-        return None;
+    let (cmp, rest) = match value.strip_prefix('>') {
+        Some(r) => (true, r),
+        // Anything that isn't `>` or `<` is not a size filter at all.
+        None => (false, value.strip_prefix('<')?),
     };
 
     let rest_lower = rest.to_lowercase();


### PR DESCRIPTION
## The bug

Apple Mail exports a mailbox as a **directory** `Inbox.mbox` containing a file called literally `mbox` — and that inner file is the path an app actually reads. `merge_mbox_files` took its source label from `input_path.file_name()`, so every message of every such mailbox was stamped:

```
X-Mbox-Source: mbox
```

The merged archive is then untraceable, which is the one thing the header exists for. It affects `mboxshell merge --source-header` and any consumer of the library (the Mbox Viewer desktop apps hit it through the same code path).

Reported against the desktop app by a reviewer merging real Apple Mail exports.

## The fix

New `mailbox_naming` module:

- `presentation_path` — climbs to the containing `.mbox` package when the path is Apple Mail's inner file, leaves everything else alone. A file named `mbox` that is *not* inside a package keeps its own name (Thunderbird stores look like that).
- `display_name` — the visible name of one mailbox: `Inbox.mbox` for `…/Account/Inbox.mbox/mbox`.
- `unique_display_names` — names a whole set, disambiguated against each other: two accounts that both have an `Inbox.mbox` become `Work/Inbox.mbox` and `Personal/Inbox.mbox`. Parent directories are prepended one at a time, capped at 4 levels, and the loop stops as soon as a name can no longer grow — otherwise two identical input paths would climb to the filesystem root forever.

`merge_mbox_files` uses those names for both the `X-Mbox-Source` value and the progress callback. The label still goes through `sanitize_header_value`, so control characters are stripped as before; a disambiguated name may now contain a `/`, which is harmless in a header value.

| Input | Label |
|---|---|
| `…/Account/Inbox.mbox/mbox` | `Inbox.mbox` |
| `…/archive.mbox` | `archive.mbox` |
| `…/backup/mbox` (not inside a package) | `mbox` |
| `…/Work/Inbox.mbox/mbox` + `…/Personal/Inbox.mbox/mbox` | `Work/Inbox.mbox`, `Personal/Inbox.mbox` |
| the same path twice | same name, terminates |

## Tests

7 new (202 total, all green). 5 unit tests on the naming rules, plus two integration tests that write real `.mbox` packages to disk, merge them, and assert the output contains `X-Mbox-Source: Inbox.mbox` / `Sent.mbox` and **not** `X-Mbox-Source: mbox`. The first of those fails on `main` and passes here.

No behaviour change for a plain merge, or for a merge whose inputs are ordinary `.mbox` files with distinct names — the existing tests were left untouched and still pass.

Version bumped to 0.6.2, CHANGELOG.md and CHANGELOG-ES.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)