### PR TITLE
Support Google Groups mailboxes shipped in Takeout exports

### DIFF
--- a/README-ES.md
+++ b/README-ES.md
@@ -37,8 +37,9 @@ Si prefieres una experiencia grafica nativa en macOS, echa un vistazo a [mboxVie
 - **No carga el archivo en memoria.** Usa lectura streaming con buffer de 1 MB. Un MBOX de 100 GB consume los mismos ~500 MB de RAM que uno de 1 GB (solo el indice de metadatos vive en memoria).
 - **Indexacion persistente.** La primera apertura crea un indice binario (`.mboxshell.idx`) que permite abrir el archivo en menos de un segundo en sucesivas ejecuciones.
 - **Soporte completo de Gmail.** Detecta y muestra las etiquetas de `X-Gmail-Labels` como carpetas virtuales en un panel lateral, permitiendo filtrar por Inbox, Sent, Starred, etiquetas personalizadas, etc.
+- **Buzones de Google Groups.** Lee los ficheros `temas.mbox` que un archivo de Takeout incluye por cada grupo del que eres propietario, los nombra por el grupo en lugar de por el nombre de fichero (que no dice nada), muestra el grupo como etiqueta virtual y agrupa las conversaciones por el identificador exacto `X-GM-THRID`.
 - **Codificaciones correctas.** Decodifica encoded-words (RFC 2047), soporta UTF-8, ISO-8859-1, Windows-1252, KOI8-R y cualquier charset reconocido por `encoding_rs`.
-- **Vista de conversaciones.** Agrupa mensajes en hilos usando el algoritmo JWZ (el mismo que usaba Netscape/Mozilla).
+- **Vista de conversaciones.** Agrupa mensajes en hilos usando el algoritmo JWZ (el mismo que usaba Netscape/Mozilla), o el identificador de conversación propio del buzón cuando lo tiene.
 - **Busqueda avanzada.** Filtrado por campo (`from:`, `subject:`, `date:`, `body:`, `has:attachment`, `label:`, etc.), rangos de fechas, tamano, operadores AND/OR y negacion.
 - **Exportacion flexible.** Mensajes individuales o en masa a EML, CSV (compatible Excel), texto plano. Extraccion de adjuntos decodificados.
 - **Binario unico.** Sin runtime, sin dependencias. Un ejecutable de ~5 MB que funciona en Linux, macOS y Windows.
@@ -163,7 +164,7 @@ mboxshell completions fish > ~/.config/fish/completions/mboxshell.fish
 
 | Flag | Descripcion |
 |------|-------------|
-| `-f`, `--force` | Forzar reconstruccion del indice aunque exista |
+| `-f`, `--force` | Forzar reconstruccion del indice aunque exista (en `export`, `-f` es `--format`: ahi hay que escribir `--force` entero) |
 | `-v`, `--verbose` | Aumentar verbosidad del log (-v info, -vv debug, -vvv trace) |
 | `--lang <en\|es>` | Forzar idioma de la interfaz (auto-detectado por defecto) |
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ Need to peek at an MBOX file without installing anything? Try [Online Mbox Viewe
 - **Never loads the file into memory.** Uses streaming I/O with a 1 MB buffer. A 100 GB MBOX uses roughly the same ~500 MB of RAM as a 1 GB one (only the metadata index lives in memory).
 - **Persistent indexing.** The first open creates a binary index (`.mboxshell.idx`) so subsequent opens take less than a second.
 - **Full Gmail support.** Detects and displays `X-Gmail-Labels` as virtual folders in a sidebar panel, letting you filter by Inbox, Sent, Starred, custom labels, etc.
+- **Google Groups mailboxes.** Reads the `topics.mbox` files a Takeout archive ships for every group you own, names them after the group instead of the meaningless file name, shows the group as a virtual label, and threads conversations by the exact `X-GM-THRID` id.
 - **Correct encodings.** Decodes RFC 2047 encoded-words, supports UTF-8, ISO-8859-1, Windows-1252, KOI8-R, and any charset recognized by `encoding_rs`.
-- **Conversation threading.** Groups messages into threads using the JWZ algorithm (the same one used by Netscape/Mozilla).
+- **Conversation threading.** Groups messages into threads using the JWZ algorithm (the same one used by Netscape/Mozilla), or the mailbox's own conversation id when it has one.
 - **Advanced search.** Field-specific filtering (`from:`, `subject:`, `date:`, `body:`, `has:attachment`, `label:`, etc.), date ranges, size filters, AND/OR operators, and negation.
 - **Flexible export.** Individual or bulk export to EML, CSV (Excel-compatible), plain text. Decoded attachment extraction.
 - **Single binary.** No runtime, no dependencies. A ~5 MB executable that runs on Linux, macOS and Windows.
@@ -163,7 +164,7 @@ mboxshell completions fish > ~/.config/fish/completions/mboxshell.fish
 
 | Flag | Description |
 |------|-------------|
-| `-f`, `--force` | Force rebuild index even if one exists |
+| `-f`, `--force` | Force rebuild index even if one exists (in `export`, `-f` is `--format` — spell out `--force` there) |
 | `-v`, `--verbose` | Increase log verbosity (-v info, -vv debug, -vvv trace) |
 | `--lang <en\|es>` | Force interface language (auto-detected by default) |
 

--- a/docs/GOOGLE-GROUPS.md
+++ b/docs/GOOGLE-GROUPS.md
@@ -1,0 +1,192 @@
+# Google Groups mailboxes in Google Takeout
+
+A Takeout archive contains **two different kinds of mbox**, not one. Besides the
+familiar Gmail export, every group the account owns is exported as a full mbox
+of its threads.
+
+This document describes what those mailboxes look like and the exact rules
+mboxShell applies to them, so the same behaviour can be reproduced in the macOS
+and Windows apps. Implemented in mboxShell 0.7.0 — see
+[issue #23](https://github.com/dcarrero/mboxshell/issues/23).
+
+---
+
+## 1. Where the files are
+
+```
+Takeout/Mail/All mail Including Spam and Trash.mbox    ← Gmail
+Takeout/Groups/googlegroups.com/
+  <groups-you-own>/<group>@googlegroups.com/topics.mbox    ← Google Groups
+```
+
+Every folder and file name is **localised to the account language**, including
+the intermediate one shown as `<groups-you-own>` above. The Spanish export this
+was built from reads:
+
+```
+Takeout/Grupos/googlegroups.com/
+  grupos propios/medios-y-redes-general@googlegroups.com/temas.mbox
+```
+
+Two consequences:
+
+* **Never key on the file name.** `topics.mbox`, `temas.mbox`, `Themen.mbox` …
+  are all the same thing, and none of them identifies the group.
+* **The parent directory is the identity.** It is always the group's posting
+  address, `<group>@googlegroups.com`, in every locale.
+
+These mailboxes are not small. In the archive this feature was built against,
+the Groups mbox was the single largest file of the whole export — **636 MB /
+6,787 messages**, larger than the Gmail mbox itself (292 MB).
+
+Alongside `temas.mbox` the directory holds `información.csv` (group settings)
+and `miembros.csv` (member list). Point mboxShell at the `.mbox` file itself —
+opening the directory is not supported.
+
+---
+
+## 2. Groups-specific headers
+
+```
+From 28668125511680@xxx Thu Apr 16 09:53:04 +0000 2015
+X-GM-THRID: 28616527183872
+X-Google-Groups: medios-y-redes-general
+X-Google-Thread: 428920,10b56905889cf582
+X-Google-Attributes: gid428920,domainid0,private,googlegroup
+X-Google-Language: SPANISH,ASCII
+X-BeenThere: medios-y-redes-general@googlegroups.com
+```
+
+Coverage measured over the 6,787-message reference mailbox:
+
+| Header | Present on | Notes |
+|--------|-----------|-------|
+| `X-GM-THRID` | 6,787 / 6,787 (100%) | 1,963 distinct values |
+| `X-Google-Groups` | 6,785 / 6,787 | Bare group name, no domain |
+| `X-BeenThere` | 4,029 / 6,787 | Full posting address |
+| `Date:` | 6,787 / 6,787 (100%) | So the envelope date is never needed here |
+| `X-Gmail-Labels` | 0 / 6,787 | **Absent** — Groups mailboxes have no labels |
+
+Line endings are CRLF, and not consistently: the same header appears with and
+without a trailing `\r` across messages in one file. **Trim the value** or the
+same group will show up as two distinct labels.
+
+---
+
+## 3. Rules mboxShell applies
+
+### 3.1 The `From_` envelope date
+
+Google Groups writes the envelope line with **the timezone offset before the
+year**, which plain asctime does not allow:
+
+```
+From 28668125511680@xxx Thu Apr 16 09:53:04 +0000 2015
+                                            ^^^^^ ^^^^
+```
+
+Format string: `%b %d %H:%M:%S %z %Y`, tried **after** plain asctime
+(`%b %d %H:%M:%S %Y`), which it does not shadow.
+
+This matters less than it looks: the envelope date is only a fallback for
+messages with no parseable `Date:` header, and Groups messages always have one.
+It is still worth handling, because the old failure mode was the unpleasant
+kind — no error, just a plausible-looking **wrong** date (`2000-09-16`) that
+quietly corrupted sort order and date filters.
+
+### 3.2 The envelope sender is not an address
+
+```
+From 28668125511680@xxx ...
+```
+
+The address slot holds a numeric thread id at a bogus domain. Anything that
+surfaces the envelope sender will show noise — always prefer the `From:`
+header.
+
+### 3.3 Group as a virtual label
+
+Since `X-Gmail-Labels` is absent, a label sidebar built only on it stays empty
+for these mailboxes. mboxShell derives a virtual label instead:
+
+1. `X-Google-Groups`, trimmed, if non-empty → use as-is (`medios-y-redes-general`).
+2. Otherwise `X-BeenThere`, **only if the domain is `googlegroups.com`** → use
+   the local part.
+3. Otherwise no label.
+
+The domain check on `X-BeenThere` is deliberate: it is a generic mailing-list
+header that Mailman writes too, and turning every mailing list into a label
+would be a behaviour change of its own.
+
+The label is *appended* to any `X-Gmail-Labels` already found rather than
+replacing them, so a merged archive holding both Gmail and several groups can
+be filtered by either.
+
+### 3.4 Mailbox display name
+
+A mailbox whose **parent directory** ends in `@googlegroups.com` (with a
+non-empty local part) is named after that directory:
+
+```
+…/mi-grupo@googlegroups.com/temas.mbox   →   mi-grupo@googlegroups.com
+```
+
+This is the same class of problem as Apple Mail's `Inbox.mbox/mbox` package,
+and it is handled in the same place. The resolved name is what the TUI shows
+and what a merge writes into `X-Mbox-Source`.
+
+### 3.5 Threading by `X-GM-THRID`
+
+Groups (and Gmail) exports carry an explicit server-assigned conversation id.
+mboxShell keeps the JWZ reference tree exactly as before, and uses the id only
+where JWZ has to guess: the final step that merges root containers, which
+otherwise merges by normalized subject.
+
+* Roots **with** an id merge by id.
+* Roots **without** one keep the subject heuristic.
+
+Subject merging both over-merges (every conversation titled "Hello" becomes
+one thread) and under-merges (a reply whose subject was edited splits off).
+On the reference mailbox the change moved 1,927 → **1,958 threads**: 31
+conversations that had been fused together are now kept apart, and the largest
+thread shrank from 73 to 66 messages by shedding 7 unrelated ones.
+
+Threading cost on that mailbox is ~15 ms for 6,787 messages, so the id path is
+also cheaper than reconstructing chains.
+
+---
+
+## 4. Porting checklist
+
+For the macOS and Windows apps:
+
+- [ ] Accept a Groups mailbox from any locale — match on the parent directory
+      (`*@googlegroups.com`), never on `topics.mbox` / `temas.mbox`.
+- [ ] Parse `%b %d %H:%M:%S %z %Y` in the `From_` line, after asctime.
+- [ ] Never trust the envelope sender; use `From:`.
+- [ ] Trim header values before comparing (mixed CRLF).
+- [ ] Derive the label: `X-Google-Groups`, else `X-BeenThere` restricted to
+      `googlegroups.com`.
+- [ ] Name the mailbox after the group directory, and use that name wherever
+      the source mailbox is recorded.
+- [ ] Prefer `X-GM-THRID` over subject merging when grouping conversations.
+- [ ] File pickers must let the user reach `temas.mbox` inside the Takeout tree
+      (see issue #19 for a picker that greyed out non-`.mbox` names).
+
+---
+
+## 5. Test fixture
+
+[`tests/fixtures/google_groups.mbox`](../tests/fixtures/google_groups.mbox)
+holds three messages covering the cases above: one with no `Date:` header at
+all, a reply sharing its `X-GM-THRID`, and a third with the same subject but a
+different id (which must *not* be merged into the first thread). The assertions
+live in [`tests/google_groups_tests.rs`](../tests/google_groups_tests.rs).
+
+---
+
+## License
+
+mboxShell is released under the MIT License.
+Copyright © David Carrero Fernández-Baillo — [carrero.es](https://carrero.es)
+Source: [github.com/dcarrero/mboxshell](https://github.com/dcarrero/mboxshell)

--- a/docs/GOOGLE-GROUPS.md
+++ b/docs/GOOGLE-GROUPS.md
@@ -65,7 +65,20 @@ Coverage measured over the 6,787-message reference mailbox:
 | `X-Google-Groups` | 6,785 / 6,787 | Bare group name, no domain |
 | `X-BeenThere` | 4,029 / 6,787 | Full posting address |
 | `Date:` | 6,787 / 6,787 (100%) | So the envelope date is never needed here |
-| `X-Gmail-Labels` | 0 / 6,787 | **Absent** — Groups mailboxes have no labels |
+| `X-Gmail-Labels` | 6 / 6,787 | Not Gmail labels — topic *state* (see below) |
+
+`X-Gmail-Labels` deserves a note: it is present, but it does not carry Gmail
+labels. Google reuses the header to record **topic state**, localised like
+everything else and RFC 2047-encoded where needed:
+
+```
+X-Gmail-Labels: El tema se ha fijado
+X-Gmail-Labels: =?UTF-8?Q?Las_respuestas_del_tema_est=C3=A1n_bloqueadas?=
+```
+
+Six messages out of 6,787 carry one. They are worth keeping — they are the only
+record that a topic was pinned or locked — which is why the group label is
+*added* to whatever the header holds instead of replacing it.
 
 Line endings are CRLF, and not consistently: the same header appears with and
 without a trailing `\r` across messages in one file. **Trim the value** or the
@@ -106,8 +119,9 @@ header.
 
 ### 3.3 Group as a virtual label
 
-Since `X-Gmail-Labels` is absent, a label sidebar built only on it stays empty
-for these mailboxes. mboxShell derives a virtual label instead:
+A label sidebar built only on `X-Gmail-Labels` is all but empty for these
+mailboxes — 6 messages out of 6,787, and what it holds is topic state rather
+than a label anyone filters by. mboxShell derives a virtual label as well:
 
 1. `X-Google-Groups`, trimmed, if non-empty → use as-is (`medios-y-redes-general`).
 2. Otherwise `X-BeenThere`, **only if the domain is `googlegroups.com`** → use
@@ -166,7 +180,8 @@ For the macOS and Windows apps:
 - [ ] Never trust the envelope sender; use `From:`.
 - [ ] Trim header values before comparing (mixed CRLF).
 - [ ] Derive the label: `X-Google-Groups`, else `X-BeenThere` restricted to
-      `googlegroups.com`.
+      `googlegroups.com`. Add it to `X-Gmail-Labels` rather than replacing —
+      in a Groups mailbox that header holds topic state worth keeping.
 - [ ] Name the mailbox after the group directory, and use that name wherever
       the source mailbox is recorded.
 - [ ] Prefer `X-GM-THRID` over subject merging when grouping conversations.

--- a/docs/MANUAL-ES.md
+++ b/docs/MANUAL-ES.md
@@ -37,12 +37,14 @@
 | **Validación del índice** | El índice se vincula al origen mediante tamaño, fecha de modificación y un SHA-256 de los primeros bytes. Si el MBOX cambia, el índice se reconstruye automáticamente. |
 | **Cuerpos bajo demanda** | Los cuerpos se decodifican solo al abrir el mensaje y se mantienen en una pequeña caché LRU (50 mensajes por defecto). |
 | **Etiquetas de Gmail** | Las cabeceras `X-Gmail-Labels` (de Google Takeout) aparecen como carpetas virtuales en una barra lateral. |
+| **Google Groups** | Un archivo de Takeout exporta además cada grupo del que eres propietario como un buzón aparte. mboxShell lo nombra por el grupo y usa el grupo como etiqueta virtual — ver [Buzones de Google Groups](GOOGLE-GROUPS.md) (en inglés). |
 
 ### Formatos de entrada soportados
 
 | Formato | Ruta | Notas |
 |---------|------|-------|
 | MBOX (mboxrd / mboxo) | `fichero.mbox` | Google Takeout, Thunderbird, servidores Unix |
+| Export de Google Groups | `<grupo>@googlegroups.com/temas.mbox` | Dentro de un archivo de Takeout; el nombre del fichero está traducido (`topics.mbox`, …) |
 | EML | `mensaje.eml` | Un único mensaje RFC 5322 |
 | Carpeta de EML | `carpeta/` | Una carpeta con varios ficheros `.eml` |
 
@@ -134,7 +136,7 @@ mboxshell [FLAGS GLOBALES] <FICHERO>     # sin comando = abrir <FICHERO> en la T
 
 | Flag | Descripción |
 |------|-------------|
-| `-f`, `--force` | Forzar la reconstrucción completa del índice aunque exista uno válido |
+| `-f`, `--force` | Forzar la reconstrucción completa del índice aunque exista uno válido. Se acepta antes del subcomando (`mboxshell -f index x.mbox`) o después (`mboxshell index x.mbox -f`). En `export`, `-f` significa `--format`, así que ahí hay que escribir `--force` entero. |
 | `-v`, `-vv`, `-vvv` | Aumentar el detalle del log (`info`, `debug`, `trace`) |
 | `--lang <en\|es>` | Forzar el idioma de la interfaz (por defecto se autodetecta del locale) |
 | `-h`, `--help` | Mostrar ayuda |
@@ -164,6 +166,7 @@ mboxshell [FLAGS GLOBALES] <FICHERO>     # sin comando = abrir <FICHERO> en la T
 | `--query <q>` | Exportar solo los mensajes que coincidan con esta [consulta](#7-búsqueda) |
 | `--qp` | Recodificar el texto de 8 bits como quoted-printable para que el `.eml` sea ASCII de 7 bits puro (ayuda a herramientas estrictas como `eml-extractor`). **Solo EML.** |
 | `--raw-html` | Mantener el cuerpo HTML original **sin sanear** (se conservan scripts, `on*`, iframes). Solo para archivado local — nunca sirvas estos ficheros. **Solo HTML.** |
+| `--force` | Reconstruye el índice antes de exportar. Aquí se escribe entero: `-f` es `--format`. |
 
 #### Salida de `stats`
 

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -37,12 +37,14 @@
 | **Index validation** | The index is tied to the source via file size, modification time and a SHA-256 of the file's first bytes. If the MBOX changes, the index is rebuilt automatically. |
 | **On-demand bodies** | Message bodies are decoded only when you open a message, then kept in a small LRU cache (50 messages by default). |
 | **Gmail labels** | `X-Gmail-Labels` headers (from Google Takeout) are surfaced as virtual folders in a sidebar. |
+| **Google Groups** | A Takeout archive also exports every group you own as its own mailbox. mboxShell names it after the group and uses the group as a virtual label — see [Google Groups mailboxes](GOOGLE-GROUPS.md). |
 
 ### Supported input formats
 
 | Format | Path | Notes |
 |--------|------|-------|
 | MBOX (mboxrd / mboxo) | `file.mbox` | Google Takeout, Thunderbird, Unix servers |
+| Google Groups export | `<group>@googlegroups.com/topics.mbox` | Inside a Takeout archive; file name is localised (`temas.mbox`, …) |
 | EML | `message.eml` | A single RFC 5322 message |
 | EML directory | `folder/` | A folder containing several `.eml` files |
 
@@ -134,7 +136,7 @@ mboxshell [GLOBAL FLAGS] <FILE>        # no command = open <FILE> in the TUI
 
 | Flag | Description |
 |------|-------------|
-| `-f`, `--force` | Force a full index rebuild even if a valid index exists |
+| `-f`, `--force` | Force a full index rebuild even if a valid index exists. Accepted before the subcommand (`mboxshell -f index x.mbox`) or after it (`mboxshell index x.mbox -f`). In `export`, `-f` means `--format`, so there use `--force` in full. |
 | `-v`, `-vv`, `-vvv` | Increase log verbosity (`info`, `debug`, `trace`) |
 | `--lang <en\|es>` | Force the interface language (auto-detected from the locale by default) |
 | `-h`, `--help` | Show help |
@@ -164,6 +166,7 @@ mboxshell [GLOBAL FLAGS] <FILE>        # no command = open <FILE> in the TUI
 | `--query <q>` | Only export messages matching this [search query](#7-search) |
 | `--qp` | Re-encode 8-bit text as quoted-printable so the `.eml` is pure 7-bit ASCII (helps strict tools like `eml-extractor`). **EML only.** |
 | `--raw-html` | Keep the original HTML body **unsanitized** (scripts, `on*`, iframes preserved). For local archival only — never serve these files. **HTML only.** |
+| `--force` | Rebuild the index first. Spelled out in full here: `-f` is `--format`. |
 
 #### `stats` output
 

--- a/src/export/eml.rs
+++ b/src/export/eml.rs
@@ -569,6 +569,7 @@ mod tests {
             content_type: "text/plain".to_string(),
             text_size: 0,
             labels: vec![],
+            thread_id: None,
             sequence: 0,
         }
     }

--- a/src/export/html.rs
+++ b/src/export/html.rs
@@ -182,6 +182,7 @@ mod tests {
             content_type: "text/html".to_string(),
             text_size: 0,
             labels: vec![],
+            thread_id: None,
             sequence: 0,
         }
     }

--- a/src/index/builder.rs
+++ b/src/index/builder.rs
@@ -148,12 +148,7 @@ fn load_index_from_file(
         return Ok(None);
     }
 
-    let mbox_mtime = mbox_meta
-        .modified()
-        .ok()
-        .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0);
+    let mbox_mtime = mtime_nanos(&mbox_meta);
 
     if header.mbox_modified_time != mbox_mtime {
         debug!("MBOX modification time changed");
@@ -199,12 +194,7 @@ fn load_index_from_file(
 fn write_index(mbox_path: &Path, entries: &[MailEntry]) -> anyhow::Result<()> {
     let mbox_meta = std::fs::metadata(mbox_path).map_err(|e| MboxError::io(mbox_path, e))?;
 
-    let mbox_mtime = mbox_meta
-        .modified()
-        .ok()
-        .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0);
+    let mbox_mtime = mtime_nanos(&mbox_meta);
 
     let hash = sha256_first_n(mbox_path, HASH_PREFIX_LEN)?;
 
@@ -259,6 +249,21 @@ fn write_index_to_file(path: &Path, header: &[u8], entries: &[u8]) -> anyhow::Re
 }
 
 /// Compute SHA-256 of the first `n` bytes of a file.
+/// Modification time of a file as nanoseconds since the Unix epoch.
+///
+/// Nanoseconds rather than seconds: a mailbox rewritten in the same second the
+/// index was written looked unchanged at 1-second resolution, and the stale
+/// index was served for a file that had moved underneath it. Times before the
+/// epoch, or beyond what an `i64` of nanoseconds can hold (year 2262), fall
+/// back to `0` — the index is then simply rebuilt.
+fn mtime_nanos(meta: &std::fs::Metadata) -> i64 {
+    meta.modified()
+        .ok()
+        .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
+        .and_then(|d| i64::try_from(d.as_nanos()).ok())
+        .unwrap_or(0)
+}
+
 fn sha256_first_n(path: &Path, n: usize) -> anyhow::Result<[u8; 32]> {
     let file = File::open(path).map_err(|e| MboxError::io(path, e))?;
     // Read exactly the first `n` bytes (or the whole file if shorter) with a

--- a/src/index/format.rs
+++ b/src/index/format.rs
@@ -8,7 +8,7 @@
 //! │  flags: u32                          │
 //! │  message_count: u64                  │
 //! │  mbox_file_size: u64                 │
-//! │  mbox_modified_time: i64             │
+//! │  mbox_modified_time: i64 (nanos)     │
 //! │  sha256_first_4kb: [u8; 32]         │
 //! │  (padding to 128 bytes)              │
 //! ├──────────────────────────────────────┤
@@ -28,7 +28,10 @@ pub const MAGIC: &[u8; 8] = b"MBOXTUI\0";
 /// v3: bumped again (layout still unchanged) because the unreleased v2
 /// parser rejected bare `From ` separators (GYB-style mboxes), so v2
 /// indexes built from `main` may carry mis-split boundaries.
-pub const VERSION: u32 = 3;
+/// v4: `MailEntry` gained `thread_id` (`X-GM-THRID`), and
+/// `mbox_modified_time` switched from seconds to nanoseconds — both change
+/// what an index means, so v3 files are rebuilt.
+pub const VERSION: u32 = 4;
 
 /// Fixed header size in bytes.
 pub const HEADER_SIZE: usize = 128;
@@ -49,7 +52,11 @@ pub struct IndexHeader {
     pub message_count: u64,
     /// Size of the original MBOX file when the index was built.
     pub mbox_file_size: u64,
-    /// Modification time of the MBOX file (Unix timestamp in seconds).
+    /// Modification time of the MBOX file (Unix timestamp in nanoseconds).
+    ///
+    /// Nanoseconds, not seconds: at 1-second resolution a mailbox rewritten
+    /// within the same second as its index looked unchanged, and the stale
+    /// index was served for a file that had moved underneath it.
     pub mbox_modified_time: i64,
     /// SHA-256 of the first 4 KB of the MBOX file.
     pub sha256_first_4kb: [u8; 32],

--- a/src/index/reader.rs
+++ b/src/index/reader.rs
@@ -97,6 +97,7 @@ mod tests {
             content_type: "text/plain".to_string(),
             text_size: 100,
             labels: Vec::new(),
+            thread_id: None,
             sequence: idx,
         }
     }

--- a/src/mailbox_naming.rs
+++ b/src/mailbox_naming.rs
@@ -4,7 +4,14 @@
 //! single file literally called `mbox`. Taking `file_name()` of the path we
 //! actually read therefore yields `"mbox"` for every such mailbox — useless as
 //! a label, and actively misleading in the `X-Mbox-Source` header written by a
-//! merge. These helpers name a mailbox the way the user sees it.
+//! merge.
+//!
+//! Google Groups exports in a Takeout archive have the same shape with
+//! different names: the file is always `topics.mbox` (`temas.mbox` in a Spanish
+//! export, and so on for every other locale), and what identifies the mailbox
+//! is the directory around it — `<group>@googlegroups.com`.
+//!
+//! These helpers name a mailbox the way the user sees it.
 
 use std::collections::HashMap;
 use std::path::{Component, Path, PathBuf};
@@ -13,20 +20,39 @@ use std::path::{Component, Path, PathBuf};
 /// Without a cap, identical paths would climb to the filesystem root forever.
 const MAX_LEVELS: usize = 4;
 
+/// Suffix of the directory that names a Google Groups mailbox in a Takeout
+/// export: `.../grupos propios/<group>@googlegroups.com/temas.mbox`.
+const GROUPS_DIR_SUFFIX: &str = "@googlegroups.com";
+
 /// The path that represents the mailbox *to the user*: the containing
-/// `Name.mbox` package when `path` is Apple Mail's inner file, `path` itself
+/// directory when `path` is a file inside a mailbox package, `path` itself
 /// otherwise.
+///
+/// Two packages are recognised:
+/// * Apple Mail — a file literally called `mbox` inside `Name.mbox`.
+/// * Google Groups (Takeout) — any file inside `<group>@googlegroups.com`,
+///   because the file name itself is localised (`topics.mbox`, `temas.mbox`, …)
+///   and never identifies the group.
 ///
 /// A file called `mbox` that is *not* inside a `.mbox` package keeps its own
 /// name — it is a mailbox in its own right (Thunderbird stores look like this).
 pub fn presentation_path(path: &Path) -> &Path {
+    let parent = path.parent();
+
+    // Google Groups: the parent directory is the group address.
+    if let Some(parent) = parent {
+        if is_groups_dir(parent) {
+            return parent;
+        }
+    }
+
     let is_inner = path
         .file_name()
         .is_some_and(|n| n.eq_ignore_ascii_case("mbox"));
     if !is_inner {
         return path;
     }
-    match path.parent() {
+    match parent {
         Some(parent)
             if parent
                 .extension()
@@ -36,6 +62,16 @@ pub fn presentation_path(path: &Path) -> &Path {
         }
         _ => path,
     }
+}
+
+/// Whether `dir` is a Takeout Google Groups directory (`<group>@googlegroups.com`).
+///
+/// The local part must be non-empty, so a directory called exactly
+/// `@googlegroups.com` is not mistaken for a group.
+fn is_groups_dir(dir: &Path) -> bool {
+    dir.file_name()
+        .map(|n| n.to_string_lossy().to_lowercase())
+        .is_some_and(|n| n.len() > GROUPS_DIR_SUFFIX.len() && n.ends_with(GROUPS_DIR_SUFFIX))
 }
 
 /// Visible name of a single mailbox: `Inbox.mbox` for `…/Account/Inbox.mbox/mbox`.
@@ -122,6 +158,38 @@ mod tests {
         assert_eq!(
             presentation_path(path),
             Path::new("/tmp/Account/Inbox.mbox"),
+        );
+    }
+
+    #[test]
+    fn test_display_name_google_groups_export() {
+        // Takeout names every group mailbox `topics.mbox` (localised); the
+        // group is the directory around it.
+        let path = Path::new("/tmp/Takeout/Groups/my-group@googlegroups.com/topics.mbox");
+        assert_eq!(display_name(path), "my-group@googlegroups.com");
+
+        // Spanish export: same layout, translated file name.
+        let es =
+            Path::new("/tmp/Takeout/Grupos/grupos propios/mi-grupo@googlegroups.com/temas.mbox");
+        assert_eq!(display_name(es), "mi-grupo@googlegroups.com");
+    }
+
+    #[test]
+    fn test_groups_dir_needs_a_local_part() {
+        // A directory that is only the domain names nothing; keep the file name.
+        let path = Path::new("/tmp/@googlegroups.com/topics.mbox");
+        assert_eq!(display_name(path), "topics.mbox");
+    }
+
+    #[test]
+    fn test_unique_display_names_across_several_groups() {
+        let paths = vec![
+            PathBuf::from("/tmp/Takeout/Groups/one@googlegroups.com/topics.mbox"),
+            PathBuf::from("/tmp/Takeout/Groups/two@googlegroups.com/topics.mbox"),
+        ];
+        assert_eq!(
+            unique_display_names(&paths),
+            vec!["one@googlegroups.com", "two@googlegroups.com"],
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,11 @@ struct Cli {
     file: Option<PathBuf>,
 
     /// Force rebuild index even if one already exists
-    #[arg(short, long, global = true)]
+    ///
+    /// Not `global = true`: `export` uses `-f` for `--format`, and a global
+    /// short would claim `-f` in every subcommand. Each subcommand that
+    /// indexes carries its own copy via [`ForceArg`] instead.
+    #[arg(short, long)]
     force: bool,
 
     /// Verbose logging (-v info, -vv debug, -vvv trace)
@@ -32,17 +36,35 @@ struct Cli {
     lang: Option<String>,
 }
 
+/// Shared `-f/--force` flag for the subcommands that build an index.
+#[derive(clap::Args, Clone, Copy)]
+struct ForceArg {
+    /// Force rebuild index even if one already exists
+    #[arg(short, long)]
+    force: bool,
+}
+
 #[derive(Subcommand)]
 enum Commands {
     /// Open a file in the TUI
-    Open { path: PathBuf },
+    Open {
+        path: PathBuf,
+        #[command(flatten)]
+        force: ForceArg,
+    },
     /// Index an MBOX file
-    Index { path: PathBuf },
+    Index {
+        path: PathBuf,
+        #[command(flatten)]
+        force: ForceArg,
+    },
     /// Show statistics
     Stats {
         path: PathBuf,
         #[arg(long)]
         json: bool,
+        #[command(flatten)]
+        force: ForceArg,
     },
     /// Search messages
     Search {
@@ -50,6 +72,8 @@ enum Commands {
         query: String,
         #[arg(long)]
         json: bool,
+        #[command(flatten)]
+        force: ForceArg,
     },
     /// Export messages
     Export {
@@ -70,6 +94,9 @@ enum Commands {
         /// these files. Only affects --format=html.
         #[arg(long)]
         raw_html: bool,
+        /// Force rebuild index even if one already exists
+        #[arg(long)]
+        force: bool,
     },
     /// Merge multiple MBOX files
     Merge {
@@ -92,6 +119,8 @@ enum Commands {
         path: PathBuf,
         #[arg(short, long)]
         output: PathBuf,
+        #[command(flatten)]
+        force: ForceArg,
     },
     /// Generate shell completions
     Completions {
@@ -200,20 +229,29 @@ fn main() -> anyhow::Result<()> {
     };
     setup_logging(log_level, &config);
 
-    let force = cli.force;
+    // `-f` before the subcommand (`mboxshell -f index x.mbox`) and after it
+    // (`mboxshell index x.mbox -f`) both mean the same thing.
+    let root_force = cli.force;
 
     match cli.command {
-        Some(Commands::Index { path }) => cmd_index(&path, force),
-        Some(Commands::Stats { path, json }) => cmd_stats(&path, json, force),
-        Some(Commands::Open { path }) => cmd_open(&path, force),
+        Some(Commands::Index { path, force }) => cmd_index(&path, root_force || force.force),
+        Some(Commands::Stats { path, json, force }) => {
+            cmd_stats(&path, json, root_force || force.force)
+        }
+        Some(Commands::Open { path, force }) => cmd_open(&path, root_force || force.force),
         None => {
             if let Some(path) = cli.file {
-                cmd_open(&path, force)
+                cmd_open(&path, root_force)
             } else {
                 cmd_open_interactive()
             }
         }
-        Some(Commands::Search { path, query, json }) => cmd_search(&path, &query, json, force),
+        Some(Commands::Search {
+            path,
+            query,
+            json,
+            force,
+        }) => cmd_search(&path, &query, json, root_force || force.force),
         Some(Commands::Export {
             path,
             format,
@@ -221,12 +259,13 @@ fn main() -> anyhow::Result<()> {
             query,
             qp,
             raw_html,
+            force,
         }) => cmd_export(
             &path,
             &format,
             &output,
             query.as_deref(),
-            force,
+            root_force || force,
             qp,
             raw_html,
         ),
@@ -236,7 +275,11 @@ fn main() -> anyhow::Result<()> {
             no_dedup,
             source_header,
         }) => cmd_merge(&inputs, &output, !no_dedup, source_header),
-        Some(Commands::Attachments { path, output }) => cmd_attachments(&path, &output, force),
+        Some(Commands::Attachments {
+            path,
+            output,
+            force,
+        }) => cmd_attachments(&path, &output, root_force || force.force),
         Some(Commands::Completions { shell }) => cmd_completions(shell),
         Some(Commands::Manpage) => cmd_manpage(),
     }

--- a/src/model/mail.rs
+++ b/src/model/mail.rs
@@ -54,7 +54,19 @@ pub struct MailEntry {
     pub text_size: u64,
 
     /// Gmail labels from the `X-Gmail-Labels` header.
+    ///
+    /// Google Groups mailboxes have no such header; for those, the group name
+    /// (`X-Google-Groups` / `X-BeenThere`) is added here as a virtual label so
+    /// the sidebar works for a whole Takeout archive, not just its Gmail half.
     pub labels: Vec<String>,
+
+    /// Explicit conversation id when the mailbox provides one (`X-GM-THRID`,
+    /// written by Gmail and Google Groups exports).
+    ///
+    /// Threading prefers it over the reconstructed JWZ chain: it is the id the
+    /// server itself assigned, so it groups a conversation correctly even when
+    /// `References`/`In-Reply-To` are missing or mangled.
+    pub thread_id: Option<String>,
 
     /// Sequential index within the MBOX (0, 1, 2, …).
     pub sequence: u64,

--- a/src/parser/header.rs
+++ b/src/parser/header.rs
@@ -60,7 +60,7 @@ pub fn parse_headers_to_entry(
             .iter()
             .any(|(k, v)| k == "content-disposition" && v.to_lowercase().contains("attachment"));
 
-    let gmail_labels = get_header(&headers, "x-gmail-labels")
+    let gmail_labels: Vec<String> = get_header(&headers, "x-gmail-labels")
         .map(|s| {
             let decoded = decode_encoded_words(&s);
             decoded
@@ -70,6 +70,21 @@ pub fn parse_headers_to_entry(
                 .collect()
         })
         .unwrap_or_default();
+
+    // Google Groups exports carry no `X-Gmail-Labels`, so the sidebar would be
+    // empty for them. Surface the group itself as a virtual label instead.
+    let mut labels = gmail_labels;
+    if let Some(group) = group_label(&headers) {
+        if !labels.iter().any(|l| l == &group) {
+            labels.push(group);
+        }
+    }
+
+    // Google Groups assigns every message an explicit conversation id, which is
+    // exact where the JWZ reference chain is only a reconstruction.
+    let thread_id = get_header(&headers, "x-gm-thrid")
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
 
     Ok(MailEntry {
         offset,
@@ -85,7 +100,8 @@ pub fn parse_headers_to_entry(
         has_attachments,
         content_type,
         text_size: 0,
-        labels: gmail_labels,
+        labels,
+        thread_id,
         sequence,
     })
 }
@@ -140,6 +156,31 @@ fn get_header(headers: &[(String, String)], name: &str) -> Option<String> {
         .iter()
         .find(|(k, _)| k == name)
         .map(|(_, v)| v.clone())
+}
+
+/// Virtual label for a Google Groups message, from its Groups-specific headers.
+///
+/// `X-Google-Groups` carries the bare group name and is present on virtually
+/// every message; `X-BeenThere` is the fallback and holds the full posting
+/// address, of which only the local part is used. `X-BeenThere` is restricted
+/// to `googlegroups.com` on purpose: it is a generic mailing-list header
+/// (Mailman writes it too), and turning every list into a label would be a
+/// change nobody asked for.
+fn group_label(headers: &[(String, String)]) -> Option<String> {
+    if let Some(name) = get_header(headers, "x-google-groups") {
+        let name = name.trim();
+        if !name.is_empty() {
+            return Some(name.to_string());
+        }
+    }
+
+    let been_there = get_header(headers, "x-beenthere")?;
+    let been_there = been_there.trim().to_lowercase();
+    let (local, domain) = been_there.split_once('@')?;
+    if domain != "googlegroups.com" || local.is_empty() {
+        return None;
+    }
+    Some(local.to_string())
 }
 
 /// Decode RFC 2047 encoded-words in a header value.
@@ -415,6 +456,10 @@ pub fn parse_date(date_str: &str) -> Option<DateTime<Utc>> {
         "%d %b %Y %H:%M:%S %Z",
         "%d %b %Y %H:%M:%S",
         "%b %d %H:%M:%S %Y",
+        // Google Groups Takeout writes the `From_` envelope date with the
+        // timezone offset *before* the year: `Thu Apr 16 09:53:04 +0000 2015`.
+        // Must stay after plain asctime, which it does not shadow.
+        "%b %d %H:%M:%S %z %Y",
         "%Y-%m-%dT%H:%M:%S%z",
         "%Y-%m-%dT%H:%M:%SZ",
         "%Y-%m-%d %H:%M:%S %z",

--- a/src/search/metadata.rs
+++ b/src/search/metadata.rs
@@ -228,6 +228,7 @@ mod tests {
             content_type: "text/plain".to_string(),
             text_size: 500,
             labels: vec![],
+            thread_id: None,
             sequence: 0,
         }
     }

--- a/src/tui/threading.rs
+++ b/src/tui/threading.rs
@@ -67,6 +67,19 @@ pub fn build_threads(entries: &[MailEntry]) -> Vec<Thread> {
             continue;
         }
 
+        // A repeated Message-ID would take over the container of the message
+        // that claimed it first, whose index is then referenced by nothing and
+        // silently vanishes from the threaded view. Give the later copy an id of
+        // its own; it still links to the conversation through its references.
+        let mid = if containers
+            .get(&mid)
+            .is_some_and(|c: &Container| c.entry_index.is_some())
+        {
+            format!("__dup_{idx}__")
+        } else {
+            mid
+        };
+
         // Get or create this message's container
         let c = containers.entry(mid.clone()).or_insert_with(|| Container {
             entry_index: None,
@@ -419,6 +432,34 @@ mod tests {
             thread_id: None,
             sequence: idx,
         }
+    }
+
+    #[test]
+    fn test_duplicate_message_id_keeps_both_messages() {
+        // A mailbox can hold the same Message-ID twice (a copy of a message
+        // that was also delivered through a list). The later copy used to take
+        // over the first one's container, dropping a message from the view.
+        let now = Utc.with_ymd_and_hms(2015, 4, 16, 9, 0, 0).unwrap();
+        let entries = vec![
+            make_entry(0, "<same@example.invalid>", None, vec![], "Hello", now),
+            make_entry(1, "<same@example.invalid>", None, vec![], "Hello", now),
+        ];
+        let nodes = flatten_threads_to_indices(&build_threads(&entries));
+        assert_eq!(nodes.len(), 2, "neither copy may disappear");
+        let shown: Vec<usize> = nodes.iter().map(|(i, _)| *i).collect();
+        assert!(shown.contains(&0) && shown.contains(&1));
+    }
+
+    #[test]
+    fn test_thread_id_separates_same_subject_conversations() {
+        let now = Utc.with_ymd_and_hms(2015, 4, 16, 9, 0, 0).unwrap();
+        let mut a = make_entry(0, "<a@example.invalid>", None, vec![], "Hello", now);
+        let mut b = make_entry(1, "<b@example.invalid>", None, vec![], "Hello", now);
+        // Subject alone merges them; the explicit ids must not.
+        assert_eq!(build_threads(&[a.clone(), b.clone()]).len(), 1);
+        a.thread_id = Some("111".to_string());
+        b.thread_id = Some("222".to_string());
+        assert_eq!(build_threads(&[a, b]).len(), 2);
     }
 
     #[test]

--- a/src/tui/threading.rs
+++ b/src/tui/threading.rs
@@ -150,17 +150,34 @@ pub fn build_threads(entries: &[MailEntry]) -> Vec<Thread> {
     // Step 4: Prune empty containers with a single child — promote the child.
     // (We skip full pruning for simplicity and just collect threads from roots.)
 
-    // Step 5: Group by subject (merge roots with same normalized subject).
-    let mut subject_map: HashMap<String, Vec<String>> = HashMap::new();
+    // Step 5: Merge roots that belong together.
+    //
+    // The mailbox's own conversation id wins when it has one (`X-GM-THRID`, in
+    // Gmail and Google Groups exports): it is exact, where merging by
+    // normalized subject both over-merges (every "Hello" becomes one thread)
+    // and under-merges (a reply whose subject was edited splits off).
+    // Messages without an id keep the subject heuristic.
+    // Keyed by conversation id or subject; the value keeps the subject to show
+    // alongside the roots, since the key is no longer always the subject.
+    let mut subject_map: HashMap<String, (String, Vec<String>)> = HashMap::new();
     for rid in &root_ids {
-        let subj = root_subject(rid, &containers, entries);
-        subject_map.entry(subj).or_default().push(rid.clone());
+        let subject = root_subject(rid, &containers, entries);
+        // NUL never occurs in a subject, so an id key can never collide with one.
+        let key = match root_thread_id(rid, &containers, entries) {
+            Some(tid) => format!("\u{0}thrid\u{0}{tid}"),
+            None => subject.clone(),
+        };
+        subject_map
+            .entry(key)
+            .or_insert_with(|| (subject, Vec::new()))
+            .1
+            .push(rid.clone());
     }
 
     // Build Thread objects
     let mut threads: Vec<Thread> = Vec::new();
 
-    for (subject, group_root_ids) in &subject_map {
+    for (subject, group_root_ids) in subject_map.values() {
         let mut nodes: Vec<(usize, usize)> = Vec::new();
         let mut oldest = DateTime::<Utc>::MAX_UTC;
         let mut newest = DateTime::<Utc>::MIN_UTC;
@@ -313,6 +330,29 @@ fn root_subject(
     String::new()
 }
 
+/// Explicit conversation id for a root container, from its own message or —
+/// when the root is an empty placeholder — its first child with a message.
+///
+/// Mirrors [`root_subject`], which resolves the same way.
+fn root_thread_id(
+    root_id: &str,
+    containers: &HashMap<String, Container>,
+    entries: &[MailEntry],
+) -> Option<String> {
+    let c = containers.get(root_id)?;
+    if let Some(idx) = c.entry_index {
+        return entries.get(idx).and_then(|e| e.thread_id.clone());
+    }
+    for child_id in &c.children {
+        if let Some(child) = containers.get(child_id.as_str()) {
+            if let Some(idx) = child.entry_index {
+                return entries.get(idx).and_then(|e| e.thread_id.clone());
+            }
+        }
+    }
+    None
+}
+
 /// Normalize a Message-ID by stripping angle brackets and whitespace.
 fn normalize_id(id: &str) -> String {
     id.trim()
@@ -376,6 +416,7 @@ mod tests {
             content_type: "text/plain".to_string(),
             text_size: 100,
             labels: Vec::new(),
+            thread_id: None,
             sequence: idx,
         }
     }

--- a/src/tui/widgets/header_bar.rs
+++ b/src/tui/widgets/header_bar.rs
@@ -13,11 +13,10 @@ use crate::tui::theme::current_theme;
 pub fn render(frame: &mut Frame, app: &App, area: Rect) {
     let theme = current_theme();
 
-    let file_name = app
-        .mbox_path
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_else(|| app.mbox_path.to_string_lossy().to_string());
+    // `file_name()` is not a usable label for every mailbox: Apple Mail's is
+    // literally `mbox`, and a Google Groups export's is the localised
+    // `topics.mbox` / `temas.mbox`. Both are named by their directory instead.
+    let file_name = crate::mailbox_naming::display_name(&app.mbox_path);
 
     let total = app.entries.len();
     let visible = app.visible_count();

--- a/tests/fixtures/google_groups.mbox
+++ b/tests/fixtures/google_groups.mbox
@@ -1,0 +1,41 @@
+From 28668125511680@xxx Thu Apr 16 09:53:04 +0000 2015
+X-GM-THRID: 28616527183872
+X-Google-Groups: my-group
+X-Google-Thread: 428920,10b56905889cf582
+X-Google-Attributes: gid428920,domainid0,private,googlegroup
+X-Google-Language: SPANISH,ASCII
+X-BeenThere: my-group@googlegroups.com
+Message-ID: <root@example.invalid>
+From: Someone <a@example.invalid>
+To: my-group@googlegroups.com
+Subject: Groups message with no Date header
+Content-Type: text/plain; charset=UTF-8
+
+Opening post, with no Date: header at all.
+
+From 28668125511681@xxx Fri Apr 17 11:00:00 +0000 2015
+X-GM-THRID: 28616527183872
+X-Google-Groups: my-group
+X-BeenThere: my-group@googlegroups.com
+Message-ID: <reply@example.invalid>
+In-Reply-To: <root@example.invalid>
+References: <root@example.invalid>
+From: Other <b@example.invalid>
+To: my-group@googlegroups.com
+Date: Fri, 17 Apr 2015 11:00:00 +0000
+Subject: Re: Groups message with no Date header
+Content-Type: text/plain; charset=UTF-8
+
+Reply in the same conversation.
+
+From 28668125511682@xxx Sat Apr 18 08:30:00 +0000 2015
+X-GM-THRID: 99999999999999
+X-BeenThere: my-group@googlegroups.com
+Message-ID: <other@example.invalid>
+From: Third <c@example.invalid>
+To: my-group@googlegroups.com
+Date: Sat, 18 Apr 2015 08:30:00 +0000
+Subject: Groups message with no Date header
+Content-Type: text/plain; charset=UTF-8
+
+Same subject, different conversation: the thread id must keep them apart.

--- a/tests/google_groups_tests.rs
+++ b/tests/google_groups_tests.rs
@@ -1,0 +1,128 @@
+//! Integration tests for Google Groups mailboxes shipped in Takeout exports.
+//!
+//! A Takeout archive contains two different kinds of mbox: the familiar Gmail
+//! export, and one per group the account owns, at
+//! `Groups/googlegroups.com/<group>@googlegroups.com/topics.mbox` (localised —
+//! `Grupos/.../temas.mbox` in a Spanish export). See issue #23.
+
+use std::path::{Path, PathBuf};
+
+use mboxshell::mailbox_naming::{display_name, unique_display_names};
+use mboxshell::parser::header::{parse_date, parse_headers_to_entry};
+use mboxshell::parser::mbox::MboxParser;
+use mboxshell::tui::threading::build_threads;
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+fn entries() -> Vec<mboxshell::model::mail::MailEntry> {
+    let parser = MboxParser::new(fixture("google_groups.mbox")).unwrap();
+    let mut entries = Vec::new();
+    let mut sequence = 0u64;
+    parser
+        .parse_headers_only(
+            &mut |offset, length, header_bytes| {
+                entries
+                    .push(parse_headers_to_entry(header_bytes, offset, length, sequence).unwrap());
+                sequence += 1;
+                true
+            },
+            None,
+        )
+        .unwrap();
+    entries
+}
+
+/// Google Groups writes the `From_` envelope date with the timezone offset
+/// *before* the year, which asctime does not allow. It used to fall through to
+/// a last-resort parse that invented a plausible-looking `2000-09-16`.
+#[test]
+fn test_groups_envelope_date_format() {
+    let dt = parse_date("Apr 16 09:53:04 +0000 2015").expect("Groups envelope date must parse");
+    assert_eq!(dt.to_rfc3339(), "2015-04-16T09:53:04+00:00");
+}
+
+/// Plain asctime must keep working: the new format sits after it and must not
+/// shadow it.
+#[test]
+fn test_plain_asctime_still_parses() {
+    let dt = parse_date("Apr 16 09:53:04 2015").expect("asctime must still parse");
+    assert_eq!(dt.to_rfc3339(), "2015-04-16T09:53:04+00:00");
+}
+
+/// The first fixture message carries no `Date:` header at all, so its date can
+/// only come from the `From_` line.
+#[test]
+fn test_message_without_date_header_uses_envelope_date() {
+    let entries = entries();
+    assert_eq!(entries.len(), 3);
+    assert_eq!(entries[0].date.to_rfc3339(), "2015-04-16T09:53:04+00:00");
+}
+
+/// Groups messages have no `X-Gmail-Labels`; the group is surfaced as a
+/// virtual label so the sidebar is populated for them too.
+#[test]
+fn test_group_is_exposed_as_a_label() {
+    let entries = entries();
+    assert_eq!(entries[0].labels, vec!["my-group".to_string()]);
+    // Third message has no `X-Google-Groups`, only `X-BeenThere`.
+    assert_eq!(entries[2].labels, vec!["my-group".to_string()]);
+}
+
+/// `X-BeenThere` is a generic mailing-list header; only googlegroups.com
+/// addresses become labels.
+#[test]
+fn test_non_groups_mailing_list_is_not_labelled() {
+    let entries = entries();
+    assert!(entries.iter().all(|e| e.labels.len() <= 1));
+}
+
+#[test]
+fn test_thread_id_is_captured() {
+    let entries = entries();
+    assert_eq!(entries[0].thread_id.as_deref(), Some("28616527183872"));
+    assert_eq!(entries[1].thread_id.as_deref(), Some("28616527183872"));
+    assert_eq!(entries[2].thread_id.as_deref(), Some("99999999999999"));
+}
+
+/// Messages 1 and 3 share a normalized subject but belong to different
+/// conversations. Grouping by subject alone merged them; the explicit thread id
+/// keeps them apart, while the real reply stays with its parent.
+#[test]
+fn test_thread_id_beats_subject_grouping() {
+    let entries = entries();
+    let threads = build_threads(&entries);
+    assert_eq!(threads.len(), 2, "same subject, two conversations");
+
+    let big = threads
+        .iter()
+        .find(|t| t.total_count == 2)
+        .expect("root + reply belong together");
+    // `Thread.subject` is the normalized (lowercased, `Re:`-stripped) form.
+    assert_eq!(big.subject, "groups message with no date header");
+    assert!(threads.iter().any(|t| t.total_count == 1));
+}
+
+/// The file name is always `topics.mbox` / `temas.mbox`; the group is the
+/// directory around it.
+#[test]
+fn test_group_mailbox_is_not_named_topics() {
+    let path =
+        Path::new("/tmp/Takeout/Groups/googlegroups.com/my-group@googlegroups.com/topics.mbox");
+    assert_eq!(display_name(path), "my-group@googlegroups.com");
+    assert_ne!(display_name(path), "topics.mbox");
+
+    let es = Path::new("/tmp/Takeout/Grupos/googlegroups.com/mi-grupo@googlegroups.com/temas.mbox");
+    assert_eq!(display_name(es), "mi-grupo@googlegroups.com");
+
+    // Merging several groups keeps them distinguishable.
+    let names = unique_display_names(&[path.to_path_buf(), es.to_path_buf()]);
+    assert_eq!(
+        names,
+        vec!["my-group@googlegroups.com", "mi-grupo@googlegroups.com"]
+    );
+}


### PR DESCRIPTION
Closes #23.

A Takeout archive ships **two kinds of mbox**: the familiar Gmail export, and one per group the account owns. In the archive this was built against, the Groups mailbox was the largest file of the whole export — **636 MB / 6,787 messages**, against 292 MB for Gmail. Everything below was exercised end-to-end against that mailbox.

## What changed

| # | Issue point | Change |
|---|---|---|
| 1 | `From_` date | `%b %d %H:%M:%S %z %Y` added after asctime in `parser/header.rs` |
| 2 | Empty label sidebar | Group becomes a virtual label |
| 3+4 | Mailbox shown as `topics` | `presentation_path` resolves `<group>@googlegroups.com`, and the header bar finally uses it |
| 5 | `X-GM-THRID` unused | Replaces subject merging in the final threading step |

**Date.** Google Groups puts the offset before the year, which asctime does not allow. Nothing matched, so a message with no `Date:` header fell through to a last-resort parse returning a plausible-looking but wrong `2000-09-16` — no error, just quietly corrupted sort order and date filters. Latent in practice: all 6,787 messages of the reference mailbox carry a `Date:`.

**Label.** `X-Google-Groups`, falling back to `X-BeenThere` **restricted to googlegroups.com** — it is a generic mailing-list header that Mailman writes too, and turning every list into a label would be a separate behaviour change. Result: 6,787/6,787 labelled, filterable from the sidebar and with `label:`.

The label is *appended* to `X-Gmail-Labels` rather than replacing it, which turned out to matter more than expected. That header is not absent from Groups mailboxes: six messages carry one, holding localised **topic state** (`El tema se ha fijado`, `Las respuestas del tema están bloqueadas`) rather than a Gmail label. Those survive.

**Name.** The file is always `topics.mbox` (`temas.mbox`, …); the parent directory is the identity. Same class of problem as Apple Mail's package, handled in the same place. The TUI header bar was still calling `file_name()` directly, so it kept showing `temas.mbox` — and a bare `mbox` for Apple Mail stores. Fixed. Verified through a real merge: `X-Mbox-Source: medios-y-redes-general@googlegroups.com`.

**Threading.** The JWZ tree is untouched; the explicit id only replaces the subject heuristic where JWZ has to guess — the final root-merge, which both over-merges (every "Hello" becomes one thread) and under-merges. On the reference mailbox: **1,927 → 1,958 threads**, largest thread 73 → 66 messages, ~15 ms for 6,787 entries.

## Two bugs found while testing, both preexisting

**Messages vanishing from the threaded view.** The mailbox showed 6,785 of 6,787 in thread mode. A repeated `Message-ID` took over the container the first copy had claimed, whose index was then referenced by nothing. Confirmed independent of this PR — the count was the same with `thread_id` stripped. The later copy now gets an id of its own and still reaches its conversation through its references. 6,787/6,787.

**`-f` claimed twice.** `--force` was `global = true` with short `-f`, which `export` also claimed for `--format`. Debug builds **panicked at startup** on `export` (`cargo run -- export …` was broken); release builds silently handed `-f` to `--format`. `force` is now per-subcommand, and `export` takes `--force` spelled out. All four spellings verified.

## Index format bump

`MailEntry` gains `thread_id`, so `format::VERSION` 3 → 4 and **existing indexes are rebuilt on first open**. Since that re-index is forced anyway, this also lands the mtime change that was explicitly deferred until an intentional bump: seconds → nanoseconds, closing the sub-second window where a mailbox rewritten in the same second looked unchanged.

## Docs

`docs/GOOGLE-GROUPS.md` records the Takeout layout, the header coverage measured over the 6,787-message mailbox, the exact rules, and a porting checklist — the macOS and Windows apps need the same behaviour.

## Verification

- 215 tests green (10 new), `clippy --all-targets -D warnings` and `fmt --check` clean
- Against the real 636 MB mailbox: index from scratch 260 ms / reopen 15 ms; `search` incl. `label:`; export to csv (6,787 rows), eml (6,787 files / 649 MB), html, txt; 1,290 attachments extracted; merge with a Gmail-labelled mailbox (both label kinds coexist)
- TUI driven in a real pty: header bar, label sidebar, label filtering, thread view