### PR TITLE
Give OR a precedence, and stop date filters from overwriting each other

### DIFF
--- a/README-ES.md
+++ b/README-ES.md
@@ -224,13 +224,16 @@ has:no-attachment                   Solo mensajes sin adjuntos
 label:Inbox                         Filtrar por etiqueta de Gmail
 date:2024-01                        Mensajes de enero 2024
 date:2024-01-01..2024-06-30         Rango de fechas
-before:2024-06-01                   Antes de una fecha
-after:2024-01-01                    Despues de una fecha
+before:2024-06-01                   Antes de una fecha (ese dia excluido)
+after:2024-01-01                    Desde una fecha (ese dia incluido)
+after:2024-01-01 before:2025-01-01  Todo 2024
 size:>1mb                           Mensajes de mas de 1 MB
+size:>1mb size:<5mb                 Entre 1 y 5 MB
 -subject:spam                       Excluir mensajes con "spam"
 "frase exacta"                      Buscar frase completa
 from:juan subject:presupuesto       AND implicito (ambos deben coincidir)
 term1 OR term2                      OR explicito
+from:a OR from:b subject:factura    OR liga mas fuerte: (a OR b) AND asunto
 ```
 
 ## Formatos de entrada soportados

--- a/README.md
+++ b/README.md
@@ -224,13 +224,16 @@ has:no-attachment                Only messages without attachments
 label:Inbox                      Filter by Gmail label
 date:2024-01                     Messages from January 2024
 date:2024-01-01..2024-06-30      Date range
-before:2024-06-01                Before a date
-after:2024-01-01                 After a date
+before:2024-06-01                Before a date (that day excluded)
+after:2024-01-01                 From a date on (that day included)
+after:2024-01-01 before:2025-01-01   All of 2024
 size:>1mb                        Messages larger than 1 MB
+size:>1mb size:<5mb              Between 1 and 5 MB
 -subject:spam                    Exclude messages with "spam" in subject
 "exact phrase"                   Search for an exact phrase
 from:john subject:budget         Implicit AND (both must match)
 term1 OR term2                   Explicit OR
+from:a OR from:b subject:budget  OR binds tighter: (a OR b) AND subject
 ```
 
 ## Supported input formats

--- a/docs/MANUAL-ES.md
+++ b/docs/MANUAL-ES.md
@@ -361,12 +361,26 @@ mboxShell tiene un único lenguaje de consulta usado tanto por el comando `searc
 | `has:attachment` | Solo mensajes con adjuntos | `has:attachment` |
 | `has:no-attachment` | Solo mensajes sin adjuntos | `has:no-attachment` |
 | `date:` | Día / mes / año exacto, o un rango | `date:2024-01-15`, `date:2024-01`, `date:2024`, `date:2024-01-01..2024-06-30` |
-| `before:` / `after:` | Límites de fecha abiertos | `before:2024-06-01`, `after:2024-01-01` |
+| `before:` / `after:` | Límites de fecha abiertos. `after:` incluye su día y `before:` no, así que juntos forman un rango semiabierto | `before:2024-06-01`, `after:2024-01-01`, `after:2024-01-01 before:2025-01-01` (todo 2024) |
 | `size:` | Comparación de tamaño | `size:>1mb`, `size:<100kb` |
 | `"…"` | Frase exacta entrecomillada | `subject:"informe mensual"` |
 | *(espacio)* | **AND** implícito — todos los términos deben coincidir | `from:juan subject:presupuesto` |
-| `OR` | **OR** explícito — coincide cualquier término | `from:ana OR from:luis` |
+| `OR` | **OR** explícito — vale cualquiera de los términos que une. Liga más fuerte que el AND implícito | `from:ana OR from:luis` |
 | `-` | **NOT** — excluir | `-subject:spam` |
+
+### Cómo se combina `OR` con lo demás
+
+`OR` liga más fuerte que el espacio que significa AND, así que
+
+```
+from:ana OR from:luis subject:factura
+```
+
+se lee como **(**`from:ana` OR `from:luis`**)** AND `subject:factura` — correo de cualquiera de los dos, pero solo sobre facturas. No hay paréntesis: una consulta es una lista de grupos unidos por AND, y `OR` es lo que mete dos términos en el mismo grupo.
+
+`OR` une *términos*. Los filtros `date:`, `before:`, `after:`, `size:` y `has:` se aplican siempre con AND por encima, así que un `OR` escrito al lado de uno de ellos lo deja como una condición normal.
+
+Repetir un filtro acota en vez de sustituir: `after:2024-01-01 before:2025-01-01` es todo 2024, y `size:>1mb size:<5mb` es lo que pese entre 1 y 5 MB.
 
 ### Texto libre de varias palabras
 

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -361,12 +361,26 @@ mboxShell has one query language used by both the CLI `search` command and the i
 | `has:attachment` | Only messages with attachments | `has:attachment` |
 | `has:no-attachment` | Only messages without attachments | `has:no-attachment` |
 | `date:` | Exact day / month / year, or a range | `date:2024-01-15`, `date:2024-01`, `date:2024`, `date:2024-01-01..2024-06-30` |
-| `before:` / `after:` | Open-ended date bounds | `before:2024-06-01`, `after:2024-01-01` |
+| `before:` / `after:` | Open-ended date bounds. `after:` includes its day, `before:` does not, so the two together read as a half-open range | `before:2024-06-01`, `after:2024-01-01`, `after:2024-01-01 before:2025-01-01` (all of 2024) |
 | `size:` | Size comparison | `size:>1mb`, `size:<100kb` |
 | `"…"` | Quoted exact phrase | `subject:"monthly report"` |
 | *(space)* | Implicit **AND** — all terms must match | `from:john subject:budget` |
-| `OR` | Explicit **OR** — any term matches | `from:alice OR from:bob` |
+| `OR` | Explicit **OR** — any of the joined terms matches. Binds tighter than the implicit AND | `from:alice OR from:bob` |
 | `-` | **NOT** — exclude | `-subject:spam` |
+
+### How `OR` combines with the rest
+
+`OR` binds tighter than the space that means AND, so
+
+```
+from:alice OR from:bob subject:invoice
+```
+
+reads as **(**`from:alice` OR `from:bob`**)** AND `subject:invoice` — mail from either sender, but only about invoices. There are no parentheses: a query is a list of AND-ed groups, and `OR` is what puts two terms in the same group.
+
+`OR` joins *terms*. The `date:`, `before:`, `after:`, `size:` and `has:` filters are always AND-ed on top, so an `OR` written next to one of them leaves it as a plain condition.
+
+Repeating a filter narrows instead of replacing: `after:2024-01-01 before:2025-01-01` is the whole of 2024, and `size:>1mb size:<5mb` is everything between 1 and 5 MB.
 
 ### Multi-word free text
 

--- a/src/search/fulltext.rs
+++ b/src/search/fulltext.rs
@@ -11,8 +11,8 @@ use tracing::debug;
 use crate::model::mail::MailEntry;
 use crate::store::reader::MboxStore;
 
-use super::metadata::all_matches_metadata;
-use super::query::{SearchField, SearchOperator, SearchQuery, SearchTerm};
+use super::metadata::{all_matches_metadata, term_matches_entry};
+use super::query::{SearchField, SearchOperator, SearchQuery, SearchTerm, TermGroup};
 
 /// Search inside message bodies by reading from the MBOX file.
 ///
@@ -28,20 +28,13 @@ pub fn search_fulltext(
     query: &SearchQuery,
     progress: &dyn Fn(usize, usize) -> bool,
 ) -> crate::error::Result<Vec<usize>> {
-    // Terms that require reading the message: body:/filename: and the
-    // free-text `All` terms (which "search everywhere": metadata or body).
-    let scan_terms: Vec<&SearchTerm> = query
-        .terms
-        .iter()
-        .filter(|t| {
-            matches!(
-                t.field,
-                SearchField::Body | SearchField::Filename | SearchField::All
-            )
-        })
-        .collect();
+    // Groups the metadata pass could not settle: those holding a body:,
+    // filename:, or free-text term (the last matches metadata *or* body).
+    // Every one of them still has to hold, so they are AND-ed, while the terms
+    // inside each are OR-ed — the same shape the metadata pass applies.
+    let scan_groups: Vec<&TermGroup> = query.groups.iter().filter(|g| g.needs_body()).collect();
 
-    if scan_terms.is_empty() {
+    if scan_groups.is_empty() {
         // Nothing to scan — all candidates pass
         return Ok(candidates.to_vec());
     }
@@ -58,7 +51,7 @@ pub fn search_fulltext(
         }
 
         let entry = &entries[idx];
-        let matches = match check_body_match(&mut store, entry, &scan_terms, query.is_or) {
+        let matches = match check_body_match(&mut store, entry, &scan_groups) {
             Ok(m) => m,
             Err(e) => {
                 debug!(offset = entry.offset, error = %e, "Skipping message in fulltext search");
@@ -77,16 +70,17 @@ pub fn search_fulltext(
     Ok(results)
 }
 
-/// Check whether a single message matches the scan terms by reading its body.
+/// Check whether a single message satisfies the deferred groups by reading its
+/// body.
 ///
 /// Handles `body:`, `filename:`, and free-text `All` terms. `All` terms match
 /// if the needle is found in the entry's metadata (subject/from/to) **or** the
-/// decoded body text — the "search everywhere" semantics users expect.
+/// decoded body text — the "search everywhere" semantics users expect. Every
+/// group must hold (AND); within a group, any term suffices (OR).
 fn check_body_match(
     store: &mut MboxStore,
     entry: &MailEntry,
-    scan_terms: &[&SearchTerm],
-    is_or: bool,
+    scan_groups: &[&TermGroup],
 ) -> crate::error::Result<bool> {
     let body = store.get_message(entry)?;
     let text = body.text.as_deref().unwrap_or("");
@@ -118,7 +112,11 @@ fn check_body_match(
                         }
                     }
             }
-            _ => true,
+            // A deferred group can hold metadata terms beside the body ones
+            // (`body:x OR subject:y`); those are judged exactly as the
+            // metadata pass would. `term_matches_entry` applies negation
+            // itself, so return its verdict directly.
+            _ => return term_matches_entry(entry, term),
         };
 
         if term.negated {
@@ -128,11 +126,9 @@ fn check_body_match(
         }
     };
 
-    let result = if is_or {
-        scan_terms.iter().any(|t| check_term(t))
-    } else {
-        scan_terms.iter().all(|t| check_term(t))
-    };
+    let result = scan_groups
+        .iter()
+        .all(|group| group.terms.iter().any(&check_term));
 
     Ok(result)
 }

--- a/src/search/metadata.rs
+++ b/src/search/metadata.rs
@@ -7,7 +7,9 @@ use chrono::Datelike;
 
 use crate::model::mail::MailEntry;
 
-use super::query::{DateFilter, SearchField, SearchOperator, SearchQuery, SearchTerm, SizeFilter};
+use super::query::{
+    DateFilter, SearchField, SearchOperator, SearchQuery, SearchTerm, SizeFilter, TermGroup,
+};
 
 /// Search the index metadata and return matching entry indices.
 ///
@@ -26,41 +28,36 @@ pub fn search_metadata(entries: &[MailEntry], query: &SearchQuery) -> Vec<usize>
         .collect()
 }
 
-/// Like [`search_metadata`], but for AND queries it does **not** require
-/// `All` (free-text "Text") terms to match metadata — those are deferred to
-/// the full-text pass in [`super::fulltext`] so a Text term can also match the
-/// message body. Field-specific terms (`subject:`, `from:`, …) and the
-/// date/size/attachment filters still apply.
+/// Like [`search_metadata`], but groups that need the message body are left
+/// undecided here — [`super::fulltext`] settles them once it has read the
+/// body. Groups that can be decided from metadata alone, and the
+/// date/size/attachment filters, still apply, so this narrows the candidate
+/// set as much as metadata allows.
 ///
-/// For OR queries this behaves identically to [`search_metadata`] (deferring
-/// `All` terms would incorrectly drop entries that match only via metadata).
+/// A group needs the body when any of its terms is `body:`, `filename:`, or a
+/// free-text term (which matches metadata *or* body).
 pub fn search_metadata_candidates(entries: &[MailEntry], query: &SearchQuery) -> Vec<usize> {
-    let defer_all = !query.is_or;
     entries
         .iter()
         .enumerate()
-        .filter(|(_, entry)| entry_matches(entry, query, defer_all))
+        .filter(|(_, entry)| entry_matches(entry, query, true))
         .map(|(i, _)| i)
         .collect()
 }
 
 /// Check whether a single entry matches the query.
 ///
-/// When `defer_all` is set, `All` (free-text) terms are ignored here — the
-/// caller is expected to verify them against the body in the full-text pass.
-fn entry_matches(entry: &MailEntry, query: &SearchQuery, defer_all: bool) -> bool {
-    // 1. Date filter (cheapest to check)
-    if let Some(ref df) = query.date_filter {
-        if !matches_date(entry, df) {
-            return false;
-        }
+/// When `defer_body` is set, groups that need the message body are skipped —
+/// the caller is expected to settle them in the full-text pass.
+fn entry_matches(entry: &MailEntry, query: &SearchQuery, defer_body: bool) -> bool {
+    // 1. Date filters (cheapest to check), all of which must hold
+    if !query.date_filters.iter().all(|df| matches_date(entry, df)) {
+        return false;
     }
 
-    // 2. Size filter
-    if let Some(ref sf) = query.size_filter {
-        if !matches_size(entry, sf) {
-            return false;
-        }
+    // 2. Size filters, all of which must hold
+    if !query.size_filters.iter().all(|sf| matches_size(entry, sf)) {
+        return false;
     }
 
     // 3. Attachment filter
@@ -70,35 +67,38 @@ fn entry_matches(entry: &MailEntry, query: &SearchQuery, defer_all: bool) -> boo
         }
     }
 
-    // 4. Text terms (skip body:/filename: terms — those need fulltext).
-    //    When `defer_all` is set, also skip free-text `All` terms so they can
-    //    be matched against the body in the full-text pass.
-    let text_terms: Vec<&SearchTerm> = query
-        .terms
+    // 4. Term groups: AND between groups, OR inside each one.
+    //
+    //    A group that needs the body is either skipped (the full-text pass
+    //    will settle it) or, when there is no full-text pass, evaluated on
+    //    metadata alone — which is what its body:/filename: terms already did
+    //    before this existed.
+    query
+        .groups
         .iter()
-        .filter(|t| t.field != SearchField::Body && t.field != SearchField::Filename)
-        .filter(|t| !(defer_all && t.field == SearchField::All))
-        .collect();
+        .all(|group| group_matches(entry, group, defer_body))
+}
 
-    if text_terms.is_empty() {
+/// Whether an entry satisfies one OR-group.
+fn group_matches(entry: &MailEntry, group: &TermGroup, defer_body: bool) -> bool {
+    if defer_body && group.needs_body() {
         return true;
     }
-
-    if query.is_or {
-        // OR: any term must match
-        text_terms
-            .iter()
-            .any(|term| term_matches_entry(entry, term))
-    } else {
-        // AND: all terms must match
-        text_terms
-            .iter()
-            .all(|term| term_matches_entry(entry, term))
-    }
+    group
+        .terms
+        .iter()
+        .any(|term| term_matches_entry(entry, term))
 }
 
 /// Check if a text term matches an entry's metadata.
-fn term_matches_entry(entry: &MailEntry, term: &SearchTerm) -> bool {
+///
+/// `Body` and `Filename` terms cannot be judged here and count as a match, so
+/// a metadata pass never rejects an entry over something only the body could
+/// settle. The full-text pass evaluates those for real.
+///
+/// Shared with [`super::fulltext`]: a group deferred to the body pass can hold
+/// metadata terms too, and those must be judged the same way in both passes.
+pub(crate) fn term_matches_entry(entry: &MailEntry, term: &SearchTerm) -> bool {
     let raw_match = match term.field {
         SearchField::All => all_matches_metadata(entry, &term.operator),
         SearchField::From => {
@@ -181,8 +181,11 @@ fn matches_date(entry: &MailEntry, filter: &DateFilter) -> bool {
     match filter {
         DateFilter::Exact(d) => date == *d,
         DateFilter::Range(start, end) => date >= *start && date <= *end,
+        // `before:` excludes its day and `after:` includes it, so
+        // `after:2024-01-01 before:2025-01-01` is exactly the year 2024 — the
+        // half-open reading, and the one Gmail's own operators use.
         DateFilter::Before(d) => date < *d,
-        DateFilter::After(d) => date > *d,
+        DateFilter::After(d) => date >= *d,
         DateFilter::Month(year, month) => date.year() == *year && date.month() == *month,
         DateFilter::Year(year) => date.year() == *year,
     }
@@ -254,6 +257,104 @@ mod tests {
         let q = parse_query("from:alice");
         let results = search_metadata(&entries, &q);
         assert_eq!(results, vec![0]);
+    }
+
+    #[test]
+    fn test_or_binds_tighter_than_and() {
+        // `(from:alice OR from:bob) AND subject:budget`. Carol's mail matches
+        // the subject only, and used to come back because `OR` turned the
+        // whole query into "any term matches".
+        let entries = vec![
+            make_entry("alice@example.com", "Budget Report", "2024-01-15"),
+            make_entry("bob@example.com", "Budget Draft", "2024-01-16"),
+            make_entry("carol@example.com", "Budget Notes", "2024-01-17"),
+            make_entry("alice@example.com", "Holiday plans", "2024-01-18"),
+        ];
+        let q = parse_query("from:alice OR from:bob subject:budget");
+        assert_eq!(search_metadata(&entries, &q), vec![0, 1]);
+    }
+
+    #[test]
+    fn test_or_group_alone_matches_any() {
+        let entries = vec![
+            make_entry("alice@example.com", "One", "2024-01-15"),
+            make_entry("bob@example.com", "Two", "2024-01-16"),
+            make_entry("carol@example.com", "Three", "2024-01-17"),
+        ];
+        let q = parse_query("from:alice OR from:bob");
+        assert_eq!(search_metadata(&entries, &q), vec![0, 1]);
+    }
+
+    #[test]
+    fn test_and_still_requires_every_group() {
+        let entries = vec![
+            make_entry("alice@example.com", "Budget", "2024-01-15"),
+            make_entry("alice@example.com", "Holiday", "2024-01-16"),
+            make_entry("bob@example.com", "Budget", "2024-01-17"),
+        ];
+        let q = parse_query("from:alice subject:budget");
+        assert_eq!(search_metadata(&entries, &q), vec![0]);
+    }
+
+    #[test]
+    fn test_or_group_combines_with_filters() {
+        // Filters are AND-ed on top of the groups, never OR-ed into them.
+        let entries = vec![
+            make_entry("alice@example.com", "One", "2024-01-15"),
+            make_entry("bob@example.com", "Two", "2023-01-16"),
+            make_entry("carol@example.com", "Three", "2024-01-17"),
+        ];
+        let q = parse_query("from:alice OR from:bob date:2024");
+        assert_eq!(search_metadata(&entries, &q), vec![0]);
+    }
+
+    #[test]
+    fn test_negation_inside_an_or_group() {
+        let entries = vec![
+            make_entry("alice@example.com", "One", "2024-01-15"),
+            make_entry("bob@example.com", "Two", "2024-01-16"),
+            make_entry("carol@example.com", "Three", "2024-01-17"),
+        ];
+        // "from bob, or anyone who is not carol" — everything but carol.
+        let q = parse_query("from:bob OR -from:carol");
+        assert_eq!(search_metadata(&entries, &q), vec![0, 1]);
+    }
+
+    #[test]
+    fn test_after_is_inclusive_and_before_is_not() {
+        // `after:X before:Y` is the half-open range [X, Y), so a full calendar
+        // year is `after:2024-01-01 before:2025-01-01`.
+        let entries = vec![
+            make_entry("a@example.com", "before", "2023-12-31"),
+            make_entry("a@example.com", "first day", "2024-01-01"),
+            make_entry("a@example.com", "mid", "2024-06-15"),
+            make_entry("a@example.com", "last day", "2024-12-31"),
+            make_entry("a@example.com", "after", "2025-01-01"),
+        ];
+        let q = parse_query("after:2024-01-01 before:2025-01-01");
+        assert_eq!(search_metadata(&entries, &q), vec![1, 2, 3]);
+
+        // Each bound on its own.
+        assert_eq!(
+            search_metadata(&entries, &parse_query("after:2024-06-15")),
+            vec![2, 3, 4]
+        );
+        assert_eq!(
+            search_metadata(&entries, &parse_query("before:2024-06-15")),
+            vec![0, 1]
+        );
+    }
+
+    #[test]
+    fn test_date_range_stays_inclusive_on_both_ends() {
+        let entries = vec![
+            make_entry("a@example.com", "before", "2023-12-31"),
+            make_entry("a@example.com", "start", "2024-01-01"),
+            make_entry("a@example.com", "end", "2024-06-30"),
+            make_entry("a@example.com", "after", "2024-07-01"),
+        ];
+        let q = parse_query("date:2024-01-01..2024-06-30");
+        assert_eq!(search_metadata(&entries, &q), vec![1, 2]);
     }
 
     #[test]

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -8,18 +8,15 @@ use std::path::Path;
 
 use crate::model::mail::MailEntry;
 
-use self::query::{parse_query, SearchField, SearchQuery};
+use self::query::{parse_query, SearchQuery};
 
 /// Whether running this query requires reading message bodies from disk
 /// (the slow, cancelable path).
 ///
 /// True when an explicit `body:`/`filename:` term is present, or when a
-/// free-text (`All`) term is used in an AND query — those search the body
-/// as well as metadata. OR queries keep `All` terms metadata-only, so they
-/// never need a body scan on their own.
+/// free-text (`All`) term is used — those search the body as well as metadata.
 pub fn needs_body_scan(query: &SearchQuery) -> bool {
-    let has_all_text = query.terms.iter().any(|t| t.field == SearchField::All);
-    query.needs_fulltext || (has_all_text && !query.is_or)
+    query.groups.iter().any(|g| g.needs_body())
 }
 
 /// High-level search: parse the query, search metadata, optionally run
@@ -35,26 +32,20 @@ pub fn execute(
 ) -> crate::error::Result<(SearchQuery, Vec<usize>)> {
     let query = parse_query(query_str);
 
-    if query.terms.is_empty()
-        && query.date_filter.is_none()
-        && query.size_filter.is_none()
-        && query.has_attachment.is_none()
-    {
+    if query.is_empty() {
         // Empty query — return all
         let all: Vec<usize> = (0..entries.len()).collect();
         return Ok((query, all));
     }
 
-    // Free-text ("Text") terms search everywhere — subject/from/to AND the
-    // message body — but only on AND queries (the popup always emits AND).
-    // On OR queries `All` terms keep metadata-only semantics to avoid dropping
-    // metadata-only matches from the candidate set.
+    // Free-text ("Text") terms search everywhere — subject/from/to *and* the
+    // message body — so they need the slow path just like `body:` does.
     let scan_bodies = needs_body_scan(&query);
 
-    // Phase 1: metadata search (fast). When we will scan bodies for `All`
-    // terms, defer them so a Text term that only appears in the body is not
-    // filtered out before the body is ever read.
-    let mut results = if scan_bodies && !query.is_or {
+    // Phase 1: metadata search (fast). When bodies will be read, groups that
+    // need one are left undecided, so a term that only appears in the body is
+    // not filtered out before the body is ever read.
+    let mut results = if scan_bodies {
         metadata::search_metadata_candidates(entries, &query)
     } else {
         metadata::search_metadata(entries, &query)
@@ -118,6 +109,56 @@ mod tests {
         assert_eq!(
             subjects,
             vec!["Hello World".to_string(), "Re: Hello World".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_or_group_over_body_and_metadata() {
+        // A group mixing a body-only word with a subject term: either side
+        // satisfies the group, so both messages come back.
+        let mut subjects = search_subjects("body:perspective OR subject:\"Meeting tomorrow\"");
+        subjects.sort();
+        assert_eq!(
+            subjects,
+            vec![
+                "Meeting tomorrow".to_string(),
+                "Message with From in body".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_or_group_narrowed_by_an_and_term() {
+        // `(body:perspective OR subject:"Meeting tomorrow") AND from:user5` —
+        // the AND term must still cut the OR group down. Before grouping, the
+        // whole query turned into an OR and returned all three.
+        let subjects =
+            search_subjects("body:perspective OR subject:\"Meeting tomorrow\" from:user5");
+        assert_eq!(subjects, vec!["Meeting tomorrow".to_string()]);
+    }
+
+    #[test]
+    fn test_two_body_groups_are_anded() {
+        // Both body words live in the same message; requiring them as separate
+        // groups must not turn into "either one".
+        assert_eq!(
+            search_subjects("body:perspective body:zzzznotpresent").len(),
+            0
+        );
+    }
+
+    #[test]
+    fn test_free_text_or_survives_the_body_pass() {
+        // Free text searches metadata *or* body. In an OR group, a term that
+        // only matches metadata must not be lost when the body pass runs.
+        let mut subjects = search_subjects("perspective OR Meeting");
+        subjects.sort();
+        assert_eq!(
+            subjects,
+            vec![
+                "Meeting tomorrow".to_string(),
+                "Message with From in body".to_string(),
+            ]
         );
     }
 

--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -30,6 +30,15 @@
 //! - `term1 OR term2` — explicit OR
 //! - `-term` — NOT (exclude)
 //! - `"exact phrase"` — quoted phrase
+//!
+//! `OR` binds tighter than the implicit AND, so
+//! `from:alice OR from:bob subject:invoice` reads as
+//! `(from:alice OR from:bob) AND subject:invoice`. There are no parentheses:
+//! a query is a list of AND-ed groups, each group a list of OR-ed terms.
+//!
+//! `OR` only joins *terms*. Date, size and attachment filters are always
+//! AND-ed, so an `OR` next to one of them (`from:a OR has:attachment`) leaves
+//! the filter as a plain AND condition.
 
 use chrono::NaiveDate;
 
@@ -64,9 +73,9 @@ pub enum DateFilter {
     Exact(NaiveDate),
     /// Inclusive range.
     Range(NaiveDate, NaiveDate),
-    /// Before a date (exclusive).
+    /// Strictly before a date; the day itself does not match.
     Before(NaiveDate),
-    /// After a date (exclusive).
+    /// On or after a date; the day itself matches.
     After(NaiveDate),
     /// All days in a month.
     Month(i32, u32),
@@ -89,22 +98,64 @@ pub struct SearchTerm {
     pub negated: bool,
 }
 
+/// One or more terms joined by `OR`. An entry satisfies the group when it
+/// matches **any** of them.
+///
+/// A group of one is the common case — a term with no `OR` beside it.
+#[derive(Debug, Clone)]
+pub struct TermGroup {
+    pub terms: Vec<SearchTerm>,
+}
+
+impl TermGroup {
+    /// Whether any term in the group has to read the message body.
+    ///
+    /// `All` (free-text) counts: it matches metadata *or* body, so the group
+    /// cannot be settled without the body unless it already matched.
+    pub fn needs_body(&self) -> bool {
+        self.terms.iter().any(|t| {
+            matches!(
+                t.field,
+                SearchField::Body | SearchField::Filename | SearchField::All
+            )
+        })
+    }
+}
+
 /// A fully parsed search query.
+///
+/// The term groups are AND-ed together and each group is OR-ed internally, so
+/// `a OR b c` is `(a OR b) AND c`. Date, size and attachment filters apply on
+/// top of all of them.
 #[derive(Debug, Clone)]
 pub struct SearchQuery {
-    /// Text-based search terms (AND by default).
-    pub terms: Vec<SearchTerm>,
-    /// Optional date filter.
-    pub date_filter: Option<DateFilter>,
-    /// Optional size filter.
-    pub size_filter: Option<SizeFilter>,
+    /// Term groups, AND-ed together.
+    pub groups: Vec<TermGroup>,
+    /// Date filters, AND-ed together, so `after:X before:Y` is a range.
+    pub date_filters: Vec<DateFilter>,
+    /// Size filters, AND-ed together, so `size:>1mb size:<10mb` is a band.
+    pub size_filters: Vec<SizeFilter>,
     /// Explicit attachment filter: `Some(true)` for has:attachment,
     /// `Some(false)` for has:no-attachment, `None` if unspecified.
     pub has_attachment: Option<bool>,
-    /// Whether any term targets the Body field (requires full-text search).
+    /// Whether any term targets the Body or Filename field (requires
+    /// full-text search).
     pub needs_fulltext: bool,
-    /// Whether this is an OR query (any term matches) vs AND (all must match).
-    pub is_or: bool,
+}
+
+impl SearchQuery {
+    /// Every term of every group, flattened.
+    pub fn all_terms(&self) -> impl Iterator<Item = &SearchTerm> {
+        self.groups.iter().flat_map(|g| g.terms.iter())
+    }
+
+    /// Whether the query carries no terms and no filters.
+    pub fn is_empty(&self) -> bool {
+        self.groups.is_empty()
+            && self.date_filters.is_empty()
+            && self.size_filters.is_empty()
+            && self.has_attachment.is_none()
+    }
 }
 
 /// Parse a query string into a structured [`SearchQuery`].
@@ -113,23 +164,34 @@ pub struct SearchQuery {
 pub fn parse_query(input: &str) -> SearchQuery {
     let input = input.trim();
 
-    let mut terms = Vec::new();
-    let mut date_filter = None;
-    let mut size_filter = None;
+    let mut groups: Vec<TermGroup> = Vec::new();
+    let mut date_filters = Vec::new();
+    let mut size_filters = Vec::new();
     let mut has_attachment = None;
     let mut needs_fulltext = false;
-    let mut is_or = false;
+    // Set by an `OR` token: the next term joins the group before it instead of
+    // opening one of its own.
+    let mut join_previous = false;
 
     let tokens = tokenize(input);
 
-    // Check for OR between tokens
-    let has_or = tokens.iter().any(|t| t == "OR");
-    if has_or {
-        is_or = true;
+    // Collect a term into the current group — the previous one right after an
+    // `OR`, a fresh one otherwise.
+    macro_rules! push_term {
+        ($term:expr) => {{
+            let term = $term;
+            match groups.last_mut() {
+                Some(group) if join_previous => group.terms.push(term),
+                _ => groups.push(TermGroup { terms: vec![term] }),
+            }
+        }};
     }
 
     for token in &tokens {
         if token == "OR" {
+            // A dangling `OR` — leading, trailing, or next to a filter rather
+            // than a term — has nothing to join and is ignored.
+            join_previous = true;
             continue;
         }
 
@@ -141,51 +203,51 @@ pub fn parse_query(input: &str) -> SearchQuery {
 
         // Field:value pairs
         if let Some(value) = token.strip_prefix("from:") {
-            terms.push(SearchTerm {
+            push_term!(SearchTerm {
                 field: SearchField::From,
                 operator: make_operator(value),
                 negated,
             });
         } else if let Some(value) = token.strip_prefix("to:") {
-            terms.push(SearchTerm {
+            push_term!(SearchTerm {
                 field: SearchField::To,
                 operator: make_operator(value),
                 negated,
             });
         } else if let Some(value) = token.strip_prefix("cc:") {
-            terms.push(SearchTerm {
+            push_term!(SearchTerm {
                 field: SearchField::Cc,
                 operator: make_operator(value),
                 negated,
             });
         } else if let Some(value) = token.strip_prefix("subject:") {
-            terms.push(SearchTerm {
+            push_term!(SearchTerm {
                 field: SearchField::Subject,
                 operator: make_operator(value),
                 negated,
             });
         } else if let Some(value) = token.strip_prefix("body:") {
             needs_fulltext = true;
-            terms.push(SearchTerm {
+            push_term!(SearchTerm {
                 field: SearchField::Body,
                 operator: make_operator(value),
                 negated,
             });
         } else if let Some(value) = token.strip_prefix("label:") {
-            terms.push(SearchTerm {
+            push_term!(SearchTerm {
                 field: SearchField::Label,
                 operator: make_operator(value),
                 negated,
             });
         } else if let Some(value) = token.strip_prefix("filename:") {
             needs_fulltext = true;
-            terms.push(SearchTerm {
+            push_term!(SearchTerm {
                 field: SearchField::Filename,
                 operator: make_operator(value),
                 negated,
             });
         } else if let Some(value) = token.strip_prefix("id:") {
-            terms.push(SearchTerm {
+            push_term!(SearchTerm {
                 field: SearchField::MessageId,
                 operator: make_operator(value),
                 negated,
@@ -197,34 +259,35 @@ pub fn parse_query(input: &str) -> SearchQuery {
                 _ => {}
             }
         } else if let Some(value) = token.strip_prefix("date:") {
-            date_filter = parse_date_filter(value);
+            // Filters accumulate instead of replacing each other, so
+            // `after:X before:Y` is a range rather than just whichever came
+            // last, and a nonsensical combination returns nothing rather than
+            // silently dropping half of what was typed.
+            date_filters.extend(parse_date_filter(value));
         } else if let Some(value) = token.strip_prefix("before:") {
-            if let Some(d) = parse_naive_date(value) {
-                date_filter = Some(DateFilter::Before(d));
-            }
+            date_filters.extend(parse_naive_date(value).map(DateFilter::Before));
         } else if let Some(value) = token.strip_prefix("after:") {
-            if let Some(d) = parse_naive_date(value) {
-                date_filter = Some(DateFilter::After(d));
-            }
+            date_filters.extend(parse_naive_date(value).map(DateFilter::After));
         } else if let Some(value) = token.strip_prefix("size:") {
-            size_filter = parse_size_filter(value);
+            size_filters.extend(parse_size_filter(value));
         } else {
             // Plain text — search All fields
-            terms.push(SearchTerm {
+            push_term!(SearchTerm {
                 field: SearchField::All,
                 operator: make_operator(token),
                 negated,
             });
         }
+
+        join_previous = false;
     }
 
     SearchQuery {
-        terms,
-        date_filter,
-        size_filter,
+        groups,
+        date_filters,
+        size_filters,
         has_attachment,
         needs_fulltext,
-        is_or,
     }
 }
 
@@ -385,12 +448,30 @@ fn parse_size_filter(value: &str) -> Option<SizeFilter> {
 mod tests {
     use super::*;
 
+    /// Every term of the query, flattened — most assertions here predate
+    /// grouping and only care about what was parsed, not how it was grouped.
+    fn terms(q: &SearchQuery) -> Vec<&SearchTerm> {
+        q.all_terms().collect()
+    }
+
+    /// The single date filter of a query that has exactly one.
+    fn only_date(q: &SearchQuery) -> &DateFilter {
+        assert_eq!(q.date_filters.len(), 1, "expected exactly one date filter");
+        &q.date_filters[0]
+    }
+
+    /// The single size filter of a query that has exactly one.
+    fn only_size(q: &SearchQuery) -> &SizeFilter {
+        assert_eq!(q.size_filters.len(), 1, "expected exactly one size filter");
+        &q.size_filters[0]
+    }
+
     #[test]
     fn test_parse_simple_query() {
         let q = parse_query("hello");
-        assert_eq!(q.terms.len(), 1);
-        assert_eq!(q.terms[0].field, SearchField::All);
-        assert!(!q.terms[0].negated);
+        assert_eq!(terms(&q).len(), 1);
+        assert_eq!(terms(&q)[0].field, SearchField::All);
+        assert!(!terms(&q)[0].negated);
         assert!(!q.needs_fulltext);
     }
 
@@ -399,32 +480,32 @@ mod tests {
         // The Search Filters "Text" field emits its value verbatim, so a
         // multi-word value tokenizes into one free-text term per word, ANDed.
         let q = parse_query("multi word search");
-        assert_eq!(q.terms.len(), 3);
-        assert!(q.terms.iter().all(|t| t.field == SearchField::All));
-        assert!(!q.is_or);
+        assert_eq!(terms(&q).len(), 3);
+        assert!(terms(&q).iter().all(|t| t.field == SearchField::All));
+        assert_eq!(q.groups.len(), 3, "no OR, so each term is its own group");
     }
 
     #[test]
     fn test_parse_field_query() {
         let q = parse_query("from:user@example.com subject:hello");
-        assert_eq!(q.terms.len(), 2);
-        assert_eq!(q.terms[0].field, SearchField::From);
-        assert_eq!(q.terms[1].field, SearchField::Subject);
+        assert_eq!(terms(&q).len(), 2);
+        assert_eq!(terms(&q)[0].field, SearchField::From);
+        assert_eq!(terms(&q)[1].field, SearchField::Subject);
     }
 
     #[test]
     fn test_parse_negation() {
         let q = parse_query("-subject:spam");
-        assert_eq!(q.terms.len(), 1);
-        assert!(q.terms[0].negated);
-        assert_eq!(q.terms[0].field, SearchField::Subject);
+        assert_eq!(terms(&q).len(), 1);
+        assert!(terms(&q)[0].negated);
+        assert_eq!(terms(&q)[0].field, SearchField::Subject);
     }
 
     #[test]
     fn test_parse_has_attachment() {
         let q = parse_query("has:attachment");
         assert_eq!(q.has_attachment, Some(true));
-        assert!(q.terms.is_empty());
+        assert!(terms(&q).is_empty());
     }
 
     #[test]
@@ -436,8 +517,7 @@ mod tests {
     #[test]
     fn test_parse_date_exact() {
         let q = parse_query("date:2024-01-15");
-        assert!(q.date_filter.is_some());
-        if let Some(DateFilter::Exact(d)) = &q.date_filter {
+        if let DateFilter::Exact(d) = only_date(&q) {
             assert_eq!(d.to_string(), "2024-01-15");
         } else {
             panic!("expected Exact date filter");
@@ -447,7 +527,7 @@ mod tests {
     #[test]
     fn test_parse_date_range() {
         let q = parse_query("date:2024-01-01..2024-06-30");
-        if let Some(DateFilter::Range(s, e)) = &q.date_filter {
+        if let DateFilter::Range(s, e) = only_date(&q) {
             assert_eq!(s.to_string(), "2024-01-01");
             assert_eq!(e.to_string(), "2024-06-30");
         } else {
@@ -458,18 +538,18 @@ mod tests {
     #[test]
     fn test_parse_date_month() {
         let q = parse_query("date:2024-01");
-        if let Some(DateFilter::Month(y, m)) = &q.date_filter {
+        if let DateFilter::Month(y, m) = only_date(&q) {
             assert_eq!(*y, 2024);
             assert_eq!(*m, 1);
         } else {
-            panic!("expected Month date filter, got {:?}", q.date_filter);
+            panic!("expected Month date filter");
         }
     }
 
     #[test]
     fn test_parse_date_year() {
         let q = parse_query("date:2024");
-        if let Some(DateFilter::Year(y)) = &q.date_filter {
+        if let DateFilter::Year(y) = only_date(&q) {
             assert_eq!(*y, 2024);
         } else {
             panic!("expected Year date filter");
@@ -478,24 +558,43 @@ mod tests {
 
     #[test]
     fn test_parse_before_after() {
-        let q = parse_query("before:2024-06-01");
-        assert!(matches!(q.date_filter, Some(DateFilter::Before(_))));
+        assert!(matches!(
+            only_date(&parse_query("before:2024-06-01")),
+            DateFilter::Before(_)
+        ));
+        assert!(matches!(
+            only_date(&parse_query("after:2024-01-01")),
+            DateFilter::After(_)
+        ));
+    }
 
-        let q = parse_query("after:2024-01-01");
-        assert!(matches!(q.date_filter, Some(DateFilter::After(_))));
+    #[test]
+    fn test_date_filters_accumulate() {
+        // `after:` and `before:` together describe a range. Only the last one
+        // used to survive, so half of what the user typed was dropped.
+        let q = parse_query("after:2024-01-01 before:2025-01-01");
+        assert_eq!(q.date_filters.len(), 2);
+        assert!(matches!(q.date_filters[0], DateFilter::After(_)));
+        assert!(matches!(q.date_filters[1], DateFilter::Before(_)));
+    }
+
+    #[test]
+    fn test_size_filters_accumulate() {
+        let q = parse_query("size:>1mb size:<10mb");
+        assert_eq!(q.size_filters.len(), 2);
     }
 
     #[test]
     fn test_parse_size_filter() {
         let q = parse_query("size:>1mb");
-        if let Some(SizeFilter::GreaterThan(b)) = &q.size_filter {
+        if let SizeFilter::GreaterThan(b) = only_size(&q) {
             assert_eq!(*b, 1024 * 1024);
         } else {
             panic!("expected GreaterThan size filter");
         }
 
         let q = parse_query("size:<100kb");
-        if let Some(SizeFilter::LessThan(b)) = &q.size_filter {
+        if let SizeFilter::LessThan(b) = only_size(&q) {
             assert_eq!(*b, 100 * 1024);
         } else {
             panic!("expected LessThan size filter");
@@ -503,7 +602,7 @@ mod tests {
 
         // Bare-byte suffix.
         let q = parse_query("size:>500b");
-        if let Some(SizeFilter::GreaterThan(b)) = &q.size_filter {
+        if let SizeFilter::GreaterThan(b) = only_size(&q) {
             assert_eq!(*b, 500);
         } else {
             panic!("expected GreaterThan size filter");
@@ -515,28 +614,94 @@ mod tests {
         // A value that overflows u64 when multiplied by the unit must yield no
         // size filter instead of panicking (debug) or wrapping (release).
         let q = parse_query("size:>99999999999gb");
-        assert!(q.size_filter.is_none());
+        assert!(q.size_filters.is_empty());
     }
 
     #[test]
     fn test_parse_body_triggers_fulltext() {
         let q = parse_query("body:important");
         assert!(q.needs_fulltext);
-        assert_eq!(q.terms[0].field, SearchField::Body);
+        assert_eq!(terms(&q)[0].field, SearchField::Body);
     }
 
     #[test]
     fn test_parse_or_query() {
         let q = parse_query("from:alice OR from:bob");
-        assert!(q.is_or);
-        assert_eq!(q.terms.len(), 2);
+        assert_eq!(q.groups.len(), 1, "OR keeps both terms in one group");
+        assert_eq!(q.groups[0].terms.len(), 2);
     }
 
     #[test]
+    fn test_or_binds_tighter_than_implicit_and() {
+        // `(from:alice OR from:bob) AND subject:invoice` — the whole query used
+        // to become an OR, so anything with a matching subject came back too.
+        let q = parse_query("from:alice OR from:bob subject:invoice");
+        assert_eq!(q.groups.len(), 2);
+        assert_eq!(q.groups[0].terms.len(), 2);
+        assert_eq!(q.groups[0].terms[0].field, SearchField::From);
+        assert_eq!(q.groups[0].terms[1].field, SearchField::From);
+        assert_eq!(q.groups[1].terms.len(), 1);
+        assert_eq!(q.groups[1].terms[0].field, SearchField::Subject);
+    }
+
+    #[test]
+    fn test_or_chain_stays_in_one_group() {
+        let q = parse_query("a OR b OR c");
+        assert_eq!(q.groups.len(), 1);
+        assert_eq!(q.groups[0].terms.len(), 3);
+    }
+
+    #[test]
+    fn test_and_only_query_is_one_group_per_term() {
+        let q = parse_query("from:alice subject:invoice");
+        assert_eq!(q.groups.len(), 2);
+        assert!(q.groups.iter().all(|g| g.terms.len() == 1));
+    }
+
+    #[test]
+    fn test_dangling_or_is_ignored() {
+        // Leading, trailing and doubled `OR` have nothing to join.
+        for input in [
+            "OR from:alice",
+            "from:alice OR",
+            "from:alice OR OR from:bob",
+        ] {
+            let q = parse_query(input);
+            assert!(!q.groups.is_empty(), "{input} parsed to nothing");
+            assert!(
+                q.all_terms().all(|t| t.field == SearchField::From),
+                "{input} produced a stray term"
+            );
+        }
+        // The doubled OR still joins the two it sits between.
+        assert_eq!(parse_query("from:alice OR OR from:bob").groups.len(), 1);
+    }
+
+    #[test]
+    fn test_or_next_to_a_filter_falls_back_to_and() {
+        // `OR` joins terms, not filters: the date filter stays an AND
+        // condition and the term next to it opens its own group.
+        let q = parse_query("date:2024 OR from:alice");
+        assert_eq!(q.date_filters.len(), 1);
+        assert_eq!(q.groups.len(), 1);
+        assert_eq!(q.groups[0].terms.len(), 1);
+    }
+
+    #[test]
+    fn test_group_needs_body() {
+        assert!(parse_query("body:hello").groups[0].needs_body());
+        assert!(parse_query("filename:report.pdf").groups[0].needs_body());
+        // Free-text searches metadata *or* body, so it needs the body too.
+        assert!(parse_query("hello").groups[0].needs_body());
+        assert!(!parse_query("subject:hello").groups[0].needs_body());
+        // A mixed group needs the body because one of its terms does.
+        assert!(parse_query("subject:hello OR body:hello").groups[0].needs_body());
+    }
+    #[test]
     fn test_parse_quoted_phrase() {
         let q = parse_query("subject:\"hello world\"");
-        assert_eq!(q.terms.len(), 1);
-        if let SearchOperator::Exact(ref s) = q.terms[0].operator {
+        assert_eq!(terms(&q).len(), 1);
+        if let SearchOperator::Exact(ref s) = terms(&q)[0].operator {
             assert_eq!(s, "hello world");
         } else {
             panic!("expected Exact operator");
@@ -546,19 +711,19 @@ mod tests {
     #[test]
     fn test_parse_combined_query() {
         let q = parse_query("from:user1 subject:budget date:2024-01..2024-06 has:attachment");
-        assert_eq!(q.terms.len(), 2);
-        assert_eq!(q.terms[0].field, SearchField::From);
-        assert_eq!(q.terms[1].field, SearchField::Subject);
-        assert!(q.date_filter.is_some());
+        assert_eq!(terms(&q).len(), 2);
+        assert_eq!(terms(&q)[0].field, SearchField::From);
+        assert_eq!(terms(&q)[1].field, SearchField::Subject);
+        assert_eq!(q.date_filters.len(), 1);
         assert_eq!(q.has_attachment, Some(true));
     }
 
     #[test]
     fn test_parse_empty_query() {
         let q = parse_query("");
-        assert!(q.terms.is_empty());
-        assert!(q.date_filter.is_none());
-        assert!(q.size_filter.is_none());
+        assert!(terms(&q).is_empty());
+        assert!(q.date_filters.is_empty());
+        assert!(q.size_filters.is_empty());
         assert!(q.has_attachment.is_none());
     }
 }


### PR DESCRIPTION
Closes the C-06/C-07 half of the July audit backlog (**BL-2**) — the item flagged there as *"the most valuable one left: user-visible wrong results"*.

## `OR` had no precedence

It was a whole-query flag. One `OR` anywhere turned **every** term into an alternative:

```
from:alice OR from:bob subject:invoice
```

did not mean "either sender, about invoices". It returned everything from alice, everything from bob, **and** everything whose subject said invoice, whoever sent it. On the real 6,787-message mailbox that is the difference between **49** hits and **2,102**.

A query is now a list of AND-ed groups, each group a list of OR-ed terms; `OR` is what puts two terms in the same group. Still no parentheses — which is what the syntax always implied.

`SearchQuery.terms` and `is_or` give way to `groups`, with `all_terms()` for callers that only want to know what was parsed.

The full-text pass follows the same shape. It used to flatten every body-ish term into one list and AND/OR them wholesale; it now defers whole *groups* and settles each after reading the body, so `body:x OR subject:y` behaves. Metadata terms inside a deferred group are judged by the metadata matcher rather than counting as an automatic match — that omission made the combination return everything on the first cut, and a test caught it.

## Two date fixes from the same corner

**`after:` is now inclusive**, `before:` stays exclusive, so `after:2024-01-01 before:2025-01-01` is exactly 2024 — the half-open reading Gmail's own operators use, and consistent with the already-inclusive `date:A..B`.

**That query was impossible anyway.** `date_filter` was a single `Option`, so the second filter silently replaced the first and only `before:` survived. Date and size filters now accumulate and are AND-ed, which also turns `size:>1mb size:<5mb` into a band instead of a rewrite.

## Verification

23 new tests (234 total), `clippy --all-targets -D warnings` and `fmt` clean.

Against the real 636 MB / 6,787-message mailbox:

| Query | Count |
|---|---|
| `from:tellado` | 1,821 |
| `from:betancourt` | 200 |
| `from:tellado OR from:betancourt` | **2,021** (exact sum) |
| `subject:vídeos` | 81 |
| `from:tellado OR from:betancourt subject:vídeos` | **49** (was the 2,102-strong union) |
| `date:2011` | 972 |
| `date:2011-01-01..2011-12-31` | 972 |
| `after:2011-01-01 before:2012-01-01` | **972** (all three agree) |
| `size:>1mb` | 160 |
| `size:>1mb size:<5mb` | 159 |

Both manuals and both READMEs document the precedence rule, the half-open date bounds, and that repeating a filter narrows instead of replacing.