### PR TITLE
v0.7.2: export --format mbox writes a selection out as a new mailbox

### DIFF
--- a/CHANGELOG-ES.md
+++ b/CHANGELOG-ES.md
@@ -4,6 +4,12 @@ Todos los cambios relevantes de mboxshell se documentan en este fichero.
 
 El formato sigue [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/) y el proyecto se ajusta a [Semantic Versioning](https://semver.org/lang/es/).
 
+## v0.7.2
+
+Exportar una selección como buzón nuevo. 7 tests nuevos (241 en total).
+
+- Función: **`export --format mbox` escribe los mensajes seleccionados en un único buzón MBOX nuevo.** Hasta ahora una selección se podía exportar a `.eml` / CSV / texto / HTML —una carpeta de ficheros— pero nunca de vuelta como buzón, así que no había forma de entregar *una parte* de un archivo en el mismo formato en que llegó. Junto con `--query` este es el flujo de entrega: filtrar una exportación grande (un volcado de Google Vault, un archivo de Takeout) hasta quedarse con los mensajes que de verdad procede entregar —una petición legal, una solicitud de registros, un buzón que tiene que leer otra persona— y producir un buzón que contenga solo esos. Un mensaje leído de un MBOX se copia byte a byte, conservando su propia línea sobre `From ` y el escapado que trajera el origen, porque reescribir el sobre solo podría corromper un archivo que ya era válido; a un mensaje sin línea sobre (uno que venía de un EML) se le sintetiza una —`asctime` de C en UTC, con el día alineado a dos columnas e independiente del locale— más el escapado con `>` de las líneas del cuerpo que empiezan por `From `, sin el cual el resultado no es un buzón legible. Cada registro termina en salto de línea. La salida se confirma con fichero temporal y renombrado, igual que la fusión, de modo que un fallo a media exportación nunca deja un buzón a medio escribir con el nombre que pidió el usuario; el fichero de origen no se toca nunca. Nuevos `export::mbox::export_mbox` y `export::mbox::mbox_record`.
+
 ## v0.7.1
 
 Semántica de búsqueda: `OR` gana precedencia y los filtros de fecha y tamaño repetidos dejan de pisarse entre sí. 23 tests nuevos (234 en total).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to mboxshell are documented in this file.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.7.2
+
+Export a selection back out as a new mailbox. 7 new tests (241 total).
+
+- Feature: **`export --format mbox` writes the selected messages to a single new MBOX mailbox.** Until now a selection could be exported as `.eml` / CSV / text / HTML — a folder of files — but never back as a mailbox, so there was no way to hand over *part* of an archive in the format it came in. Combined with `--query` this is the delivery flow: filter a large export (a Google Vault dump, a Takeout archive) down to the messages that actually belong in a handover — a legal request, a records request, a mailbox someone else has to read — and produce a mailbox containing only those. A message read out of an MBOX is copied byte for byte, keeping its own `From ` envelope line and whatever quoting the source used, because rewriting an envelope could only corrupt an archive that was already valid; a message with no envelope line (one that came from an EML) gets one synthesized — C `asctime` in UTC with the day space-padded to two columns, locale-independent — plus `>`-quoting of body lines starting with `From `, without which the result is not a readable mailbox. Every record ends in a newline. The output is committed by temp-file-and-rename, like the merge, so a mid-export failure never leaves a half-written mailbox under the name the user asked for; the source file is never touched. New `export::mbox::export_mbox` and `export::mbox::mbox_record`.
+
 ## v0.7.1
 
 Search semantics: `OR` gains a precedence, and repeated date/size filters stop overwriting each other. 23 new tests (234 total).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "mboxshell"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mboxshell"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 rust-version = "1.85"
 description = "Fast terminal viewer for MBOX files of any size. Open, search and export emails from Gmail Takeout backups (50GB+) without loading them into memory."

--- a/README-ES.md
+++ b/README-ES.md
@@ -131,6 +131,9 @@ mboxshell search correo.mbox "has:attachment subject:factura" --json
 mboxshell export correo.mbox --format eml --output ./emails/
 mboxshell export correo.mbox --format csv --output resumen.csv
 
+# Entregar solo una parte del archivo: un buzón nuevo con lo que coincide
+mboxshell export correo.mbox --format mbox --query "from:legal@acme.com" -o entrega.mbox
+
 # Extraer adjuntos
 mboxshell attachments correo.mbox --output ./adjuntos/
 
@@ -155,7 +158,7 @@ mboxshell completions fish > ~/.config/fish/completions/mboxshell.fish
 | `mboxshell index <ruta> [-f/--force]` | Construir o reconstruir el indice binario |
 | `mboxshell stats <ruta> [--json]` | Mostrar estadisticas de un archivo MBOX |
 | `mboxshell search <ruta> <consulta> [--json]` | Buscar mensajes desde la linea de comandos |
-| `mboxshell export <ruta> -f <formato> -o <salida> [--query <q>]` | Exportar mensajes (formatos: eml, csv, txt, html) |
+| `mboxshell export <ruta> -f <formato> -o <salida> [--query <q>]` | Exportar mensajes (formatos: eml, csv, txt, html, mbox) |
 | `mboxshell merge <archivos...> -o <salida> [--no-dedup] [--source-header]` | Combinar varios archivos MBOX en uno |
 | `mboxshell attachments <ruta> -o <salida>` | Extraer todos los adjuntos |
 | `mboxshell completions <shell>` | Generar completions de shell (bash, zsh, fish, powershell, elvish) |

--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ mboxshell search mail.mbox "has:attachment subject:invoice" --json
 mboxshell export mail.mbox --format eml --output ./emails/
 mboxshell export mail.mbox --format csv --output summary.csv
 
+# Hand over only part of an archive: a new mailbox with just the matches
+mboxshell export mail.mbox --format mbox --query "from:legal@acme.com" -o handover.mbox
+
 # Extract attachments
 mboxshell attachments mail.mbox --output ./attachments/
 
@@ -155,7 +158,7 @@ mboxshell completions fish > ~/.config/fish/completions/mboxshell.fish
 | `mboxshell index <path> [-f/--force]` | Build or rebuild the binary index |
 | `mboxshell stats <path> [--json]` | Show statistics about an MBOX file |
 | `mboxshell search <path> <query> [--json]` | Search messages from the command line |
-| `mboxshell export <path> -f <format> -o <output> [--query <q>]` | Export messages (formats: eml, csv, txt, html) |
+| `mboxshell export <path> -f <format> -o <output> [--query <q>]` | Export messages (formats: eml, csv, txt, html, mbox) |
 | `mboxshell merge <files...> -o <output> [--no-dedup] [--source-header]` | Merge multiple MBOX files into one |
 | `mboxshell attachments <path> -o <output>` | Extract all attachments |
 | `mboxshell completions <shell>` | Generate shell completions (bash, zsh, fish, powershell, elvish) |

--- a/docs/MANUAL-ES.md
+++ b/docs/MANUAL-ES.md
@@ -114,6 +114,9 @@ mboxshell search correo.mbox "from:user@gmail.com date:2024"
 # Exportar a ficheros .eml individuales
 mboxshell export correo.mbox --format eml --output ./emails/
 
+# Exportar solo los mensajes que coinciden como un buzón nuevo
+mboxshell export correo.mbox --format mbox --query "subject:factura" -o facturas.mbox
+
 # Extraer todos los adjuntos
 mboxshell attachments correo.mbox --output ./adjuntos/
 
@@ -161,8 +164,8 @@ mboxshell [FLAGS GLOBALES] <FICHERO>     # sin comando = abrir <FICHERO> en la T
 
 | Opción | Descripción |
 |--------|-------------|
-| `-f`, `--format <fmt>` | `eml` (por defecto), `csv`, `txt` (o `text`), `html` |
-| `-o`, `--output <ruta>` | Carpeta de salida (formatos por mensaje) o fichero (csv) — **obligatorio** |
+| `-f`, `--format <fmt>` | `eml` (por defecto), `csv`, `txt` (o `text`), `html`, `mbox` |
+| `-o`, `--output <ruta>` | Carpeta de salida (formatos por mensaje) o fichero (`csv`, `mbox`) — **obligatorio**. Si le das una carpeta, `csv`/`mbox` escriben dentro `export.csv` / `export.mbox`. |
 | `--query <q>` | Exportar solo los mensajes que coincidan con esta [consulta](#7-búsqueda) |
 | `--qp` | Recodificar el texto de 8 bits como quoted-printable para que el `.eml` sea ASCII de 7 bits puro (ayuda a herramientas estrictas como `eml-extractor`). **Solo EML.** |
 | `--raw-html` | Mantener el cuerpo HTML original **sin sanear** (se conservan scripts, `on*`, iframes). Solo para archivado local — nunca sirvas estos ficheros. **Solo HTML.** |
@@ -411,11 +414,21 @@ mboxshell search correo.mbox "has:attachment subject:factura" --json
 | CSV | `csv` | un único fichero `.csv` resumen | UTF-8 con BOM (compatible con Excel); separador configurable |
 | Texto plano | `txt` / `text` | un `.txt` por mensaje | Cuerpo de texto decodificado |
 | HTML | `html` | un `.html` independiente por mensaje | Cuerpo saneado por defecto; `--raw-html` lo deja intacto (solo archivado local) |
+| MBOX | `mbox` | un único buzón `.mbox` nuevo | La selección escrita de vuelta como buzón. Los mensajes leídos de un MBOX se copian byte a byte; a los que no tienen línea sobre se les sintetiza la línea `From ` y el escapado de `From `. El fichero de origen nunca se modifica. |
 
 Combínalo con `--query` para exportar solo los mensajes coincidentes:
 
 ```bash
 mboxshell export correo.mbox -f eml -o ./salida/ --query "label:Importante after:2023-01-01"
+```
+
+`--format mbox` junto con `--query` es el flujo de entrega: filtrar un archivo grande hasta quedarse
+con los mensajes que de verdad procede entregar —una petición legal, una solicitud de registros, un
+buzón que tiene que leer otra persona— y producir un buzón que contenga solo esos.
+
+```bash
+mboxshell export export-vault.mbox --format mbox -o entrega.mbox \
+  --query "from:cfo@acme.com after:2024-01-01 before:2024-06-30"
 ```
 
 En la TUI, pulsa `e` sobre un mensaje para abrir el popup de exportación y elegir un formato de forma interactiva.

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -114,6 +114,9 @@ mboxshell search mail.mbox "from:user@gmail.com date:2024"
 # Export to individual .eml files
 mboxshell export mail.mbox --format eml --output ./emails/
 
+# Export just the matching messages as a new mailbox
+mboxshell export mail.mbox --format mbox --query "subject:invoice" -o invoices.mbox
+
 # Extract every attachment
 mboxshell attachments mail.mbox --output ./attachments/
 
@@ -161,8 +164,8 @@ mboxshell [GLOBAL FLAGS] <FILE>        # no command = open <FILE> in the TUI
 
 | Option | Description |
 |--------|-------------|
-| `-f`, `--format <fmt>` | `eml` (default), `csv`, `txt` (or `text`), `html` |
-| `-o`, `--output <path>` | Output directory (per-message formats) or file (csv) — **required** |
+| `-f`, `--format <fmt>` | `eml` (default), `csv`, `txt` (or `text`), `html`, `mbox` |
+| `-o`, `--output <path>` | Output directory (per-message formats) or file (`csv`, `mbox`) — **required**. Given a directory, `csv`/`mbox` write `export.csv` / `export.mbox` inside it. |
 | `--query <q>` | Only export messages matching this [search query](#7-search) |
 | `--qp` | Re-encode 8-bit text as quoted-printable so the `.eml` is pure 7-bit ASCII (helps strict tools like `eml-extractor`). **EML only.** |
 | `--raw-html` | Keep the original HTML body **unsanitized** (scripts, `on*`, iframes preserved). For local archival only — never serve these files. **HTML only.** |
@@ -411,11 +414,21 @@ mboxshell search mail.mbox "has:attachment subject:invoice" --json
 | CSV | `csv` | a single `.csv` summary file | UTF-8 with BOM (Excel-friendly); separator configurable |
 | Plain text | `txt` / `text` | one `.txt` per message | Decoded text body |
 | HTML | `html` | one standalone `.html` per message | Body sanitized by default; `--raw-html` keeps it untouched (local archival only) |
+| MBOX | `mbox` | a single new `.mbox` mailbox | The selection written back out as a mailbox. Messages read from an MBOX are copied byte for byte; ones without an envelope line get a `From ` line and `From `-quoting synthesized. The source file is never modified. |
 
 Combine with `--query` to export only matching messages:
 
 ```bash
 mboxshell export mail.mbox -f eml -o ./out/ --query "label:Important after:2023-01-01"
+```
+
+`--format mbox` plus `--query` is the handover flow: filter a large archive down to the messages
+that actually belong in a delivery — a legal request, a records request, a mailbox someone else
+has to read — and produce a mailbox containing only those.
+
+```bash
+mboxshell export vault-export.mbox --format mbox -o handover.mbox \
+  --query "from:cfo@acme.com after:2024-01-01 before:2024-06-30"
 ```
 
 In the TUI, press `e` on a message to open the export popup and choose a format interactively.

--- a/src/export/mbox.rs
+++ b/src/export/mbox.rs
@@ -1,4 +1,4 @@
-//! Merge multiple MBOX files into one.
+//! Write MBOX mailboxes: merge several into one, or export a selection as a new one.
 
 use std::collections::HashSet;
 use std::io::Write;
@@ -6,6 +6,8 @@ use std::path::{Path, PathBuf};
 
 use crate::index::builder;
 use crate::mailbox_naming;
+use crate::model::mail::MailEntry;
+use crate::store::reader::MboxStore;
 
 /// Statistics returned by a merge operation.
 #[derive(Debug)]
@@ -141,6 +143,98 @@ pub fn merge_mbox_files(
     })
 }
 
+/// Write `entries` out as a single new MBOX mailbox at `output`.
+///
+/// This is the delivery half of the tool: filter a large archive down to the
+/// messages that actually belong in a handover — a legal request, a records
+/// request, a mailbox someone else has to read — and produce a mailbox holding
+/// only those. The source file is never touched.
+///
+/// The progress callback receives `(current, total)` and returns the number of
+/// messages written.
+pub fn export_mbox(
+    store: &mut MboxStore,
+    entries: &[&MailEntry],
+    output: &Path,
+    progress: &dyn Fn(usize, usize),
+) -> anyhow::Result<usize> {
+    // Same commit discipline as the merge: write to a sibling temp file and
+    // rename on success, so a mid-export error never leaves a half-written
+    // mailbox behind under the name the user asked for.
+    let tmp_output = output.with_extension("mbox.tmp");
+    let mut out_file = std::io::BufWriter::new(std::fs::File::create(&tmp_output)?);
+
+    let total = entries.len();
+    for (i, entry) in entries.iter().enumerate() {
+        progress(i, total);
+        let raw = store.get_raw_message(entry)?;
+        out_file.write_all(&mbox_record(&raw, entry))?;
+    }
+    progress(total, total);
+
+    out_file.flush()?;
+    drop(out_file);
+    std::fs::rename(&tmp_output, output)?;
+
+    Ok(total)
+}
+
+/// One mbox record: separator line, message, trailing newline.
+///
+/// A message read out of an MBOX already carries its own `From ` line and
+/// whatever quoting the source used, so it is copied verbatim — rewriting the
+/// envelope could only corrupt an archive that was already valid. A message
+/// that came from an EML has neither, so both are synthesized.
+pub fn mbox_record(raw: &[u8], entry: &MailEntry) -> Vec<u8> {
+    let mut out = if raw.starts_with(b"From ") {
+        raw.to_vec()
+    } else {
+        let mut v = from_line(entry);
+        append_from_quoted(&mut v, raw);
+        v
+    };
+    if out.last() != Some(&b'\n') {
+        out.push(b'\n');
+    }
+    out
+}
+
+/// `From sender Thu Jan  4 09:00:00 2024` — the mbox separator line.
+///
+/// The timestamp is C `asctime` in UTC with the day-of-month space-padded to
+/// two columns (`%e`). It must not follow the machine's locale; chrono's
+/// weekday and month names are fixed English, so the format stays stable.
+fn from_line(entry: &MailEntry) -> Vec<u8> {
+    let stamp = entry.date.format("%a %b %e %H:%M:%S %Y");
+
+    // Whitespace inside the address would split the line into extra fields.
+    let address: String = entry
+        .from
+        .address
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+    let sender = if address.is_empty() {
+        "MAILER-DAEMON"
+    } else {
+        address.as_str()
+    };
+
+    format!("From {sender} {stamp}\n").into_bytes()
+}
+
+/// Append `raw`, prefixing body lines that start with `From ` with `>` so they
+/// are not read back as the start of the next message.
+fn append_from_quoted(out: &mut Vec<u8>, raw: &[u8]) {
+    out.reserve(raw.len());
+    for line in raw.split_inclusive(|&b| b == b'\n') {
+        if line.starts_with(b"From ") {
+            out.push(b'>');
+        }
+        out.extend_from_slice(line);
+    }
+}
+
 /// Insert an `X-Mbox-Source: <source>` header into a raw MBOX message.
 ///
 /// The header is placed right after the `From ` envelope line (so it becomes
@@ -206,6 +300,127 @@ fn sanitize_header_value(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A message stamped 2024-01-04 09:00:00 UTC — a single-digit day, so the
+    /// two-column padding of the `From ` line is actually exercised.
+    fn sample_entry() -> MailEntry {
+        use crate::model::address::EmailAddress;
+        use chrono::TimeZone;
+        MailEntry {
+            offset: 0,
+            length: 100,
+            date: chrono::Utc.with_ymd_and_hms(2024, 1, 4, 9, 0, 0).unwrap(),
+            from: EmailAddress {
+                display_name: "Test User".to_string(),
+                address: "test@example.com".to_string(),
+            },
+            to: vec![],
+            cc: vec![],
+            subject: "Hello".to_string(),
+            message_id: "<msg@test>".to_string(),
+            in_reply_to: None,
+            references: vec![],
+            has_attachments: false,
+            content_type: "text/plain".to_string(),
+            text_size: 50,
+            labels: vec![],
+            sequence: 0,
+            thread_id: None,
+        }
+    }
+
+    #[test]
+    fn test_mbox_record_keeps_mbox_message_verbatim() {
+        let raw = b"From user@x.com Thu Jan  4 10:00:00 2024\nSubject: Hi\n\nbody\n";
+        let out = mbox_record(raw, &sample_entry());
+        // A message that already came out of a mailbox is copied as-is:
+        // rewriting its envelope line could only corrupt a valid archive.
+        assert_eq!(out, raw.to_vec());
+    }
+
+    #[test]
+    fn test_mbox_record_adds_envelope_line_for_eml() {
+        let raw = b"Subject: Hi\n\nbody\n";
+        let out = String::from_utf8(mbox_record(raw, &sample_entry())).unwrap();
+        // asctime, UTC, day space-padded to two columns and locale-independent.
+        assert!(
+            out.starts_with("From test@example.com Thu Jan  4 09:00:00 2024\n"),
+            "unexpected envelope line: {out}"
+        );
+        assert!(out.contains("Subject: Hi"));
+    }
+
+    #[test]
+    fn test_mbox_record_quotes_from_lines_in_eml_body() {
+        let raw = b"Subject: Hi\n\nFrom here it broke\nok\n";
+        let out = String::from_utf8(mbox_record(raw, &sample_entry())).unwrap();
+        // Otherwise that body line reads back as the start of the next message.
+        assert!(out.contains("\n>From here it broke\n"), "not quoted: {out}");
+        assert!(out.contains("\nok\n"));
+    }
+
+    #[test]
+    fn test_mbox_record_ends_with_newline() {
+        let raw = b"Subject: Hi\n\nno trailing newline";
+        let out = mbox_record(raw, &sample_entry());
+        assert_eq!(out.last(), Some(&b'\n'));
+    }
+
+    #[test]
+    fn test_from_line_falls_back_to_mailer_daemon() {
+        let mut entry = sample_entry();
+        entry.from.address = String::new();
+        let line = String::from_utf8(from_line(&entry)).unwrap();
+        // An empty sender would leave "From  Thu…", which parses as a message
+        // whose sender is the weekday.
+        assert!(line.starts_with("From MAILER-DAEMON "), "got: {line}");
+    }
+
+    #[test]
+    fn test_from_line_strips_whitespace_from_address() {
+        let mut entry = sample_entry();
+        entry.from.address = "a b@x.com".to_string();
+        let line = String::from_utf8(from_line(&entry)).unwrap();
+        // Whitespace would split the line into extra fields.
+        assert!(line.starts_with("From ab@x.com Thu Jan  4 "), "got: {line}");
+    }
+
+    #[test]
+    fn test_export_mbox_writes_a_readable_mailbox() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("source.mbox");
+        std::fs::write(
+            &src,
+            b"From a@x Thu Jan 01 00:00:00 2024\nMessage-ID: <1@x>\nSubject: A\n\nbody\n\
+              From b@x Fri Jan 02 00:00:00 2024\nMessage-ID: <2@x>\nSubject: B\n\nhi\n\
+              From c@x Sat Jan 03 00:00:00 2024\nMessage-ID: <3@x>\nSubject: C\n\nbye\n",
+        )
+        .unwrap();
+
+        let entries = builder::build_index(&src, false, None).unwrap();
+        assert_eq!(entries.len(), 3);
+        let mut store = MboxStore::open(&src).unwrap();
+
+        // Export a selection — the whole point: only these go in the handover.
+        let selection = vec![&entries[0], &entries[2]];
+        let out = dir.path().join("selection.mbox");
+        let n = export_mbox(&mut store, &selection, &out, &|_, _| {}).unwrap();
+        assert_eq!(n, 2);
+
+        // The result must be a mailbox the tool can read back.
+        let reexported = builder::build_index(&out, true, None).unwrap();
+        assert_eq!(
+            reexported.len(),
+            2,
+            "the export must re-index as 2 messages"
+        );
+        assert_eq!(reexported[0].subject, "A");
+        assert_eq!(reexported[1].subject, "C");
+        // The source is never touched.
+        assert_eq!(builder::build_index(&src, true, None).unwrap().len(), 3);
+        // And no temp file is left behind on success.
+        assert!(!dir.path().join("selection.mbox.tmp").exists());
+    }
 
     #[test]
     fn test_non_dedup_merge_preserves_bytes() {

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -589,14 +589,20 @@ msg!(cli_txt_files, ".txt file(s)", "fichero(s) .txt");
 msg!(cli_exported_html, "Exported", "Exportado");
 msg!(cli_html_files, ".html file(s)", "fichero(s) .html");
 msg!(
+    cli_exported_mbox,
+    "Exported MBOX mailbox to",
+    "Buz\u{f3}n MBOX exportado en"
+);
+msg!(cli_mbox_messages, "message(s)", "mensaje(s)");
+msg!(
     cli_unknown_format,
     "Unknown export format",
     "Formato de exportaci\u{f3}n desconocido"
 );
 msg!(
     cli_supported_formats,
-    "Supported: eml, csv, txt, html",
-    "Soportados: eml, csv, txt, html"
+    "Supported: eml, csv, txt, html, mbox",
+    "Soportados: eml, csv, txt, html, mbox"
 );
 msg!(
     cli_merge_complete,

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,8 +78,13 @@ enum Commands {
     /// Export messages
     Export {
         path: PathBuf,
+        /// Output format: eml, csv, txt, html or mbox. `mbox` writes the
+        /// selection (see --query) to a single new mailbox file — the way to
+        /// hand over only part of an archive.
         #[arg(short, long, default_value = "eml")]
         format: String,
+        /// Destination. A folder for eml/txt/html; a file for csv and mbox
+        /// (a folder gets `export.csv` / `export.mbox` written inside it).
         #[arg(short, long)]
         output: PathBuf,
         #[arg(long)]
@@ -581,6 +586,34 @@ fn cmd_export(
                 i18n::cli_exported_html(),
                 count,
                 i18n::cli_html_files()
+            );
+        }
+        "mbox" => {
+            // One new mailbox holding just the selection — the handover flow.
+            // Like CSV this writes a file, not a folder of files.
+            let mbox_path = if output.extension().is_some() {
+                output.to_path_buf()
+            } else {
+                output.join("export.mbox")
+            };
+            if let Some(parent) = mbox_path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let count = mboxshell::export::mbox::export_mbox(
+                &mut store,
+                &selected,
+                &mbox_path,
+                &|current, _total| {
+                    pb.set_position(current as u64);
+                },
+            )?;
+            pb.finish_and_clear();
+            println!(
+                "  {} {} ({} {})",
+                i18n::cli_exported_mbox(),
+                mbox_path.display(),
+                count,
+                i18n::cli_mbox_messages()
             );
         }
         _ => {


### PR DESCRIPTION
## Why

Exporting a selection could produce `.eml` / CSV / text / HTML — a folder of files — but never a
mailbox. So there was no way to hand over *part* of an archive in the format it arrived in.

That is a real workflow: reviewing a large Google Vault or Takeout export and filtering it down to
the messages that actually belong in a delivery — a legal request, a records request, a mailbox
someone else has to read — and producing a mailbox containing only those.

## What

**`export::mbox::export_mbox`** (+ `mbox_record`), next to the existing `merge_mbox_files`, and
**`export --format mbox`** in the CLI, combinable with `--query`.

- A message that already came out of an MBOX is copied **byte for byte**, keeping its own `From `
  envelope line and whatever quoting the source used — rewriting an envelope could only corrupt an
  archive that was already valid.
- A message with no envelope line (one that came from an EML) gets one synthesized: C `asctime` in
  UTC with the day space-padded to two columns, locale-independent, plus `>`-quoting of body lines
  starting with `From `. Without both, the result is not a readable mailbox.
- Every record ends in a newline; the output is committed by temp-file-and-rename, like the merge,
  so a mid-export failure never leaves a half-written mailbox under the requested name. The source
  file is never touched.

## Tests

7 new (**241 total**), `cargo fmt --check` and `cargo clippy --all-targets -D warnings` clean.
Covers verbatim copy, envelope synthesis, `From `-quoting, the trailing newline, the `MAILER-DAEMON`
and whitespace fallbacks for the sender, and an end-to-end export that re-indexes as a mailbox while
leaving the source intact. Also exercised end to end through the CLI.

Rebased on v0.7.1. Same shape as #22: the change lives in the engine shared with the desktop apps,
so it ships to both.